### PR TITLE
Fix npm distribution, add RELEASE doc

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+*.log
+*.tmp
+coverage/
+h3c/
+node_modules/
+.*
+build/
+test/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. This library adheres to a versioning policy described in [the README](./README.md#versioning). The public API of this library consists of the functions exported in [h3core.js](./lib/h3core.js).
 
+## [Unreleased]
+
+## [3.0.1] - 2018-06-18
+### Fixed
+- Fixed npm distribution
+
 ## [3.0.0] - 2018-06-18
 ### Added
 -   First public release.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,14 @@
+# Release Process
+
+Please note the [versioning guidelines](./README.md#versioning).
+
+1. Create a PR "Preparing for release X.Y.Z" against master branch
+    * Update `package.json` version to `X.Y.Z`
+    * Alter CHANGELOG.md from `[Unreleased]` to `[X.Y.Z] YYYY-MM-DD`
+
+2. Create a release "Release X.Y.Z" on Github
+    * Create Tag `vX.Y.Z`
+    * Copy CHANGELOG.md into the release notes
+
+3. Publish to NPM
+    * `npm publish`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "h3-js",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Emscripten transpiled libh3 'bindings' for Node/Web JS",
   "author": "David Ellis <d.f.ellis@ieee.org>",
   "contributors": [


### PR DESCRIPTION
- Fixes npm distribution by adding `.npmignore` file, effectively whitelisting `dist` directory
- Adds `RELEASE.md` with release guidelines

In this case I'm not going to make a separate release PR, but that will be the process going forward.