### PR TITLE
Add auto-gen'd H3 version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # h3-js
 
-[![Build Status](https://travis-ci.org/uber/h3-js.svg?branch=master)](https://travis-ci.org/uber/h3-js) [![Coverage Status](https://coveralls.io/repos/github/uber/h3-js/badge.svg?branch=master)](https://coveralls.io/github/uber/h3-js?branch=master)
+[![H3 Version](https://img.shields.io/badge/h3-v3.1.1-blue.svg)](https://github.com/uber/h3) [![Build Status](https://travis-ci.org/uber/h3-js.svg?branch=master)](https://travis-ci.org/uber/h3-js) [![Coverage Status](https://coveralls.io/repos/github/uber/h3-js/badge.svg?branch=master)](https://coveralls.io/github/uber/h3-js?branch=master)
 
 The `h3-js` library provides a pure-JavaScript version of the [H3 Core Library](https://github.com/uber/h3), a hexagon-based geographic grid system. It can be used either in Node >= 4 or in the browser. The core library is transpiled from C using [emscripten](http://kripken.github.io/emscripten-site), offering full parity with the C API and highly efficient operations.
 

--- a/doc-files/README.tmpl.md
+++ b/doc-files/README.tmpl.md
@@ -1,6 +1,6 @@
 # h3-js
 
-[![Build Status](https://travis-ci.org/uber/h3-js.svg?branch=master)](https://travis-ci.org/uber/h3-js) [![Coverage Status](https://coveralls.io/repos/github/uber/h3-js/badge.svg?branch=master)](https://coveralls.io/github/uber/h3-js?branch=master)
+[![H3 Version](https://img.shields.io/badge/h3-v{{h3Version}}-blue.svg)](https://github.com/uber/h3) [![Build Status](https://travis-ci.org/uber/h3-js.svg?branch=master)](https://travis-ci.org/uber/h3-js) [![Coverage Status](https://coveralls.io/repos/github/uber/h3-js/badge.svg?branch=master)](https://coveralls.io/github/uber/h3-js?branch=master)
 
 The `h3-js` library provides a pure-JavaScript version of the [H3 Core Library](https://github.com/uber/h3), a hexagon-based geographic grid system. It can be used either in Node >= 4 or in the browser. The core library is transpiled from C using [emscripten](http://kripken.github.io/emscripten-site), offering full parity with the C API and highly efficient operations.
 

--- a/doc-files/insert-version.js
+++ b/doc-files/insert-version.js
@@ -1,0 +1,6 @@
+const fs = require('fs');
+const path = require('path');
+
+module.exports.h3Version = function h3Version() {
+    return fs.readFileSync(path.join(__dirname, '..', 'H3_VERSION'), 'utf-8').trim();
+};

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "prepublish": "yarn dist",
     "init-docker": "docker run -dit --name emscripten -v $(pwd):/src trzeci/emscripten:sdk-tag-1.37.40-64bit bash",
     "build-emscripten": "docker exec -it emscripten bash .build-emscripten.sh",
-    "build-docs": "jsdoc2md --global-index-format grouped --partial doc-files/scope.hbs --separators --template doc-files/README.tmpl.md lib/h3core.js > README.md",
+    "build-docs": "jsdoc2md --global-index-format grouped --partial doc-files/scope.hbs --helper ./doc-files/insert-version.js --separators --template doc-files/README.tmpl.md lib/h3core.js > README.md",
     "prettier": "prettier --write --single-quote --no-bracket-spacing --print-width=100 'lib/**/*.js' 'build/**/*.js' 'test/**/*.js'"
   },
   "devDependencies": {


### PR DESCRIPTION
Adds [![H3 Version](https://img.shields.io/badge/h3-v3.1.1-blue.svg)](https://github.com/uber/h3) to the README, shimming in the version automagically.