### PR TITLE
Modified the Travis configuration file to enable automated FOSSA scans.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
 
 before_script:
   - yarn build-emscripten
+  - "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | sudo bash"
 
 script:
   - yarn lint
@@ -22,6 +23,7 @@ script:
   - yarn check-prettier
   - yarn check-docs
   - yarn cover
+  - fossa
 
 after_success:
   - npm install -g coveralls


### PR DESCRIPTION
I'm from FOSSA and I'm working with the Uber OSPO to automate license scanning. In addition to the changes in this PR, we may also need to add an API key as an environmental variable in the build environment.