### PR TITLE
Fix TypeScript libdef; add CI script to validate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ script:
   - yarn test-fast
   - yarn check-prettier
   - yarn check-docs
+  - yarn check-tsd
   - yarn cover
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ const coordinates = h3.h3SetToMultiPolygon(hexagons, true);
     * [.h3GetResolution(h3Index)](#module_h3.h3GetResolution) ⇒ <code>Number</code>
     * [.geoToH3(lat, lng, res)](#module_h3.geoToH3) ⇒ <code>H3Index</code>
     * [.h3ToGeo(h3Index)](#module_h3.h3ToGeo) ⇒ <code>Array.&lt;Number&gt;</code>
-    * [.h3ToGeoBoundary(h3Index, formatAsGeoJson)](#module_h3.h3ToGeoBoundary) ⇒ <code>Array.&lt;Array&gt;</code>
+    * [.h3ToGeoBoundary(h3Index, formatAsGeoJson)](#module_h3.h3ToGeoBoundary) ⇒ <code>Array.&lt;Array.&lt;Number&gt;&gt;</code>
     * [.h3ToParent(h3Index, res)](#module_h3.h3ToParent) ⇒ <code>H3Index</code>
     * [.h3ToChildren(h3Index, res)](#module_h3.h3ToChildren) ⇒ <code>Array.&lt;H3Index&gt;</code>
     * [.h3ToCenterChild(h3Index, res)](#module_h3.h3ToCenterChild) ⇒ <code>H3Index</code>
@@ -103,7 +103,7 @@ const coordinates = h3.h3SetToMultiPolygon(hexagons, true);
     * [.kRingDistances(h3Index, ringSize)](#module_h3.kRingDistances) ⇒ <code>Array.&lt;Array.&lt;H3Index&gt;&gt;</code>
     * [.hexRing(h3Index, ringSize)](#module_h3.hexRing) ⇒ <code>Array.&lt;H3Index&gt;</code>
     * [.polyfill(coordinates, res, isGeoJson)](#module_h3.polyfill) ⇒ <code>Array.&lt;H3Index&gt;</code>
-    * [.h3SetToMultiPolygon(h3Indexes, formatAsGeoJson)](#module_h3.h3SetToMultiPolygon) ⇒ <code>Array.&lt;Array&gt;</code>
+    * [.h3SetToMultiPolygon(h3Indexes, formatAsGeoJson)](#module_h3.h3SetToMultiPolygon) ⇒ <code>Array.&lt;Array.&lt;Array.&lt;Array.&lt;Number&gt;&gt;&gt;&gt;</code>
     * [.compact(h3Set)](#module_h3.compact) ⇒ <code>Array.&lt;H3Index&gt;</code>
     * [.uncompact(compactedSet, res)](#module_h3.uncompact) ⇒ <code>Array.&lt;H3Index&gt;</code>
     * [.h3IndexesAreNeighbors(origin, destination)](#module_h3.h3IndexesAreNeighbors) ⇒ <code>Boolean</code>
@@ -113,7 +113,7 @@ const coordinates = h3.h3SetToMultiPolygon(hexagons, true);
     * [.h3UnidirectionalEdgeIsValid(edgeIndex)](#module_h3.h3UnidirectionalEdgeIsValid) ⇒ <code>Boolean</code>
     * [.getH3IndexesFromUnidirectionalEdge(edgeIndex)](#module_h3.getH3IndexesFromUnidirectionalEdge) ⇒ <code>Array.&lt;H3Index&gt;</code>
     * [.getH3UnidirectionalEdgesFromHexagon(h3Index)](#module_h3.getH3UnidirectionalEdgesFromHexagon) ⇒ <code>Array.&lt;H3Index&gt;</code>
-    * [.getH3UnidirectionalEdgeBoundary(edgeIndex, formatAsGeoJson)](#module_h3.getH3UnidirectionalEdgeBoundary) ⇒ <code>Array.&lt;Array&gt;</code>
+    * [.getH3UnidirectionalEdgeBoundary(edgeIndex, formatAsGeoJson)](#module_h3.getH3UnidirectionalEdgeBoundary) ⇒ <code>Array.&lt;Array.&lt;Number&gt;&gt;</code>
     * [.h3Distance(origin, destination)](#module_h3.h3Distance) ⇒ <code>Number</code>
     * [.h3Line(origin, destination)](#module_h3.h3Line) ⇒ <code>Array.&lt;H3Index&gt;</code>
     * [.experimentalH3ToLocalIj(origin, destination)](#module_h3.experimentalH3ToLocalIj) ⇒ <code>Object</code>
@@ -248,12 +248,12 @@ Get the lat,lon center of a given hexagon
 
 <a name="module_h3.h3ToGeoBoundary"></a>
 
-### h3.h3ToGeoBoundary(h3Index, formatAsGeoJson) ⇒ <code>Array.&lt;Array&gt;</code>
+### h3.h3ToGeoBoundary(h3Index, formatAsGeoJson) ⇒ <code>Array.&lt;Array.&lt;Number&gt;&gt;</code>
 Get the vertices of a given hexagon (or pentagon), as an array of [lat, lng]
 points. For pentagons and hexagons on the edge of an icosahedron face, this
 function may return up to 10 vertices.
 
-**Returns**: <code>Array.&lt;Array&gt;</code> - Array of [lat, lng] pairs  
+**Returns**: <code>Array.&lt;Array.&lt;Number&gt;&gt;</code> - Array of [lat, lng] pairs  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -372,7 +372,7 @@ expected to be holes.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| coordinates | <code>Array.&lt;Array&gt;</code> | Array of loops, or a single loop |
+| coordinates | <code>Array.&lt;Array.&lt;Number&gt;&gt;</code> \| <code>Array.&lt;Array.&lt;Array.&lt;Number&gt;&gt;&gt;</code> | Array of loops, or a single loop |
 | res | <code>Number</code> | Resolution of hexagons to return |
 | isGeoJson | <code>Boolean</code> | Whether to expect GeoJson-style [lng, lat]                                  pairs instead of [lat, lng] |
 
@@ -381,13 +381,13 @@ expected to be holes.
 
 <a name="module_h3.h3SetToMultiPolygon"></a>
 
-### h3.h3SetToMultiPolygon(h3Indexes, formatAsGeoJson) ⇒ <code>Array.&lt;Array&gt;</code>
+### h3.h3SetToMultiPolygon(h3Indexes, formatAsGeoJson) ⇒ <code>Array.&lt;Array.&lt;Array.&lt;Array.&lt;Number&gt;&gt;&gt;&gt;</code>
 Get the outlines of a set of H3 hexagons, returned in GeoJSON MultiPolygon
 format (an array of polygons, each with an array of loops, each an array of
 coordinates). Coordinates are returned as [lat, lng] pairs unless GeoJSON
 is requested.
 
-**Returns**: <code>Array.&lt;Array&gt;</code> - MultiPolygon-style output.  
+**Returns**: <code>Array.&lt;Array.&lt;Array.&lt;Array.&lt;Number&gt;&gt;&gt;&gt;</code> - MultiPolygon-style output.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -538,11 +538,11 @@ every neighbor)
 
 <a name="module_h3.getH3UnidirectionalEdgeBoundary"></a>
 
-### h3.getH3UnidirectionalEdgeBoundary(edgeIndex, formatAsGeoJson) ⇒ <code>Array.&lt;Array&gt;</code>
+### h3.getH3UnidirectionalEdgeBoundary(edgeIndex, formatAsGeoJson) ⇒ <code>Array.&lt;Array.&lt;Number&gt;&gt;</code>
 Get the vertices of a given edge as an array of [lat, lng] points. Note that for edges that
 cross the edge of an icosahedron face, this may return 3 coordinates.
 
-**Returns**: <code>Array.&lt;Array&gt;</code> - Array of geo coordinate pairs  
+**Returns**: <code>Array.&lt;Array.&lt;Number&gt;&gt;</code> - Array of geo coordinate pairs  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/lib/h3core.js
+++ b/lib/h3core.js
@@ -366,7 +366,7 @@ function readGeoBoundary(geoBoundary, geoJsonCoords, closedLoop) {
  * @private
  * @param {Number}  polygon         C pointer to LinkedGeoPolygon struct
  * @param {Boolean} formatAsGeoJson Whether to provide GeoJSON output: [lng, lat], closed loops
- * @return {Array[]}                MultiPolygon-style output.
+ * @return {Number[][][][]}         MultiPolygon-style output.
  */
 function readMultiPolygon(polygon, formatAsGeoJson) {
     const output = [];
@@ -563,7 +563,7 @@ export function h3ToGeo(h3Index) {
  * @static
  * @param  {H3Index} h3Index        H3 index
  * @param {Boolean} formatAsGeoJson Whether to provide GeoJSON output: [lng, lat], closed loops
- * @return {Array[]}                Array of [lat, lng] pairs
+ * @return {Number[][]}             Array of [lat, lng] pairs
  */
 export function h3ToGeoBoundary(h3Index, formatAsGeoJson) {
     const geoBoundary = C._malloc(SZ_GEOBOUNDARY);
@@ -702,7 +702,8 @@ export function hexRing(h3Index, ringSize) {
  * The first loop is the perimeter of the polygon, and subsequent loops are
  * expected to be holes.
  * @static
- * @param  {Array[]}  coordinates   Array of loops, or a single loop
+ * @param  {Number[][] | Number[][][]} coordinates
+ *                                  Array of loops, or a single loop
  * @param  {Number} res             Resolution of hexagons to return
  * @param  {Boolean} isGeoJson      Whether to expect GeoJson-style [lng, lat]
  *                                  pairs instead of [lat, lng]
@@ -738,7 +739,7 @@ export function polyfill(coordinates, res, isGeoJson) {
  * @param {H3Index[]} h3Indexes       H3 indexes to get outlines for
  * @param {Boolean}   formatAsGeoJson Whether to provide GeoJSON output:
  *                                    [lng, lat], closed loops
- * @return {Array[]}                  MultiPolygon-style output.
+ * @return {Number[][][][]}           MultiPolygon-style output.
  */
 export function h3SetToMultiPolygon(h3Indexes, formatAsGeoJson) {
     // Early exit on empty input
@@ -927,7 +928,7 @@ export function getH3UnidirectionalEdgesFromHexagon(h3Index) {
  * @static
  * @param  {H3Index} edgeIndex      H3 index of the edge
  * @param {Boolean} formatAsGeoJson Whether to provide GeoJSON output: [lng, lat]
- * @return {Array[]}                Array of geo coordinate pairs
+ * @return {Number[][]}             Array of geo coordinate pairs
  */
 export function getH3UnidirectionalEdgeBoundary(edgeIndex, formatAsGeoJson) {
     const geoBoundary = C._malloc(SZ_GEOBOUNDARY);

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "docker-emscripten-browser": "yarn docker-emscripten-run -s ENVIRONMENT=web -o libh3-browser.js && mv out/libh3-browser.js dist",
     "check-prettier": "yarn prettier && git diff --exit-code",
     "check-docs": "yarn build-docs && git diff --exit-code",
+    "check-tsd": "yarn build-tsd && tsc --strict --noEmit dist/types.d.ts",
     "lint": "eslint lib* test/*",
     "test": "yarn lint && yarn test-fast",
     "test-fast": "yarn test-raw | faucet",
@@ -79,7 +80,8 @@
     "prettier": "^1.12.1",
     "rollup": "^1.7.0",
     "tape": "^4.8.0",
-    "tsd-jsdoc": "^2.3.1"
+    "tsd-jsdoc": "^2.3.1",
+    "typescript": "^3.6.3"
   },
   "resolutions": {
     "lodash": "4.17.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6908,6 +6908,11 @@ typescript@>=2.8.3, typescript@^3.2.1:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
+typescript@^3.6.3:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
+  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
+
 typical@^2.4.2, typical@^2.6.0, typical@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/typical/-/typical-2.6.1.tgz#5c080e5d661cbbe38259d2e70a3c7253e873881d"


### PR DESCRIPTION
- Adds a `check-tsd` script to validate the TypeScript libdef
- Adds `check-tsd` to Travis
- Fixes related type errors

Fixes #63