### PR TITLE
Accept integer input

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,31 +91,31 @@ const coordinates = h3.h3SetToMultiPolygon(hexagons, true);
     * [.h3IsPentagon(h3Index)](#module_h3.h3IsPentagon) ⇒ <code>boolean</code>
     * [.h3IsResClassIII(h3Index)](#module_h3.h3IsResClassIII) ⇒ <code>boolean</code>
     * [.h3GetBaseCell(h3Index)](#module_h3.h3GetBaseCell) ⇒ <code>number</code>
-    * [.h3GetFaces(h3Index)](#module_h3.h3GetFaces) ⇒ <code>Array.&lt;number&gt;</code>
+    * [.h3GetFaces(h3Index)](#module_h3.h3GetFaces) ⇒ <code>[ &#x27;Array&#x27; ].&lt;number&gt;</code>
     * [.h3GetResolution(h3Index)](#module_h3.h3GetResolution) ⇒ <code>number</code>
     * [.geoToH3(lat, lng, res)](#module_h3.geoToH3) ⇒ <code>H3Index</code>
-    * [.h3ToGeo(h3Index)](#module_h3.h3ToGeo) ⇒ <code>Array.&lt;number&gt;</code>
-    * [.h3ToGeoBoundary(h3Index, [formatAsGeoJson])](#module_h3.h3ToGeoBoundary) ⇒ <code>Array.&lt;Array.&lt;number&gt;&gt;</code>
+    * [.h3ToGeo(h3Index)](#module_h3.h3ToGeo) ⇒ <code>[ &#x27;Array&#x27; ].&lt;number&gt;</code>
+    * [.h3ToGeoBoundary(h3Index, [formatAsGeoJson])](#module_h3.h3ToGeoBoundary) ⇒ <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;number&gt;&gt;</code>
     * [.h3ToParent(h3Index, res)](#module_h3.h3ToParent) ⇒ <code>H3Index</code>
-    * [.h3ToChildren(h3Index, res)](#module_h3.h3ToChildren) ⇒ <code>Array.&lt;H3Index&gt;</code>
+    * [.h3ToChildren(h3Index, res)](#module_h3.h3ToChildren) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
     * [.h3ToCenterChild(h3Index, res)](#module_h3.h3ToCenterChild) ⇒ <code>H3Index</code>
-    * [.kRing(h3Index, ringSize)](#module_h3.kRing) ⇒ <code>Array.&lt;H3Index&gt;</code>
-    * [.kRingDistances(h3Index, ringSize)](#module_h3.kRingDistances) ⇒ <code>Array.&lt;Array.&lt;H3Index&gt;&gt;</code>
-    * [.hexRing(h3Index, ringSize)](#module_h3.hexRing) ⇒ <code>Array.&lt;H3Index&gt;</code>
-    * [.polyfill(coordinates, res, [isGeoJson])](#module_h3.polyfill) ⇒ <code>Array.&lt;H3Index&gt;</code>
-    * [.h3SetToMultiPolygon(h3Indexes, [formatAsGeoJson])](#module_h3.h3SetToMultiPolygon) ⇒ <code>Array.&lt;Array.&lt;Array.&lt;Array.&lt;number&gt;&gt;&gt;&gt;</code>
-    * [.compact(h3Set)](#module_h3.compact) ⇒ <code>Array.&lt;H3Index&gt;</code>
-    * [.uncompact(compactedSet, res)](#module_h3.uncompact) ⇒ <code>Array.&lt;H3Index&gt;</code>
+    * [.kRing(h3Index, ringSize)](#module_h3.kRing) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
+    * [.kRingDistances(h3Index, ringSize)](#module_h3.kRingDistances) ⇒ <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;H3Index&gt;&gt;</code>
+    * [.hexRing(h3Index, ringSize)](#module_h3.hexRing) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
+    * [.polyfill(coordinates, res, [isGeoJson])](#module_h3.polyfill) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
+    * [.h3SetToMultiPolygon(h3Indexes, [formatAsGeoJson])](#module_h3.h3SetToMultiPolygon) ⇒ <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;Array.&lt;Array.&lt;number&gt;&gt;&gt;&gt;</code>
+    * [.compact(h3Set)](#module_h3.compact) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
+    * [.uncompact(compactedSet, res)](#module_h3.uncompact) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
     * [.h3IndexesAreNeighbors(origin, destination)](#module_h3.h3IndexesAreNeighbors) ⇒ <code>boolean</code>
     * [.getH3UnidirectionalEdge(origin, destination)](#module_h3.getH3UnidirectionalEdge) ⇒ <code>H3Index</code>
     * [.getOriginH3IndexFromUnidirectionalEdge(edgeIndex)](#module_h3.getOriginH3IndexFromUnidirectionalEdge) ⇒ <code>H3Index</code>
     * [.getDestinationH3IndexFromUnidirectionalEdge(edgeIndex)](#module_h3.getDestinationH3IndexFromUnidirectionalEdge) ⇒ <code>H3Index</code>
     * [.h3UnidirectionalEdgeIsValid(edgeIndex)](#module_h3.h3UnidirectionalEdgeIsValid) ⇒ <code>boolean</code>
-    * [.getH3IndexesFromUnidirectionalEdge(edgeIndex)](#module_h3.getH3IndexesFromUnidirectionalEdge) ⇒ <code>Array.&lt;H3Index&gt;</code>
-    * [.getH3UnidirectionalEdgesFromHexagon(h3Index)](#module_h3.getH3UnidirectionalEdgesFromHexagon) ⇒ <code>Array.&lt;H3Index&gt;</code>
-    * [.getH3UnidirectionalEdgeBoundary(edgeIndex, [formatAsGeoJson])](#module_h3.getH3UnidirectionalEdgeBoundary) ⇒ <code>Array.&lt;Array.&lt;number&gt;&gt;</code>
+    * [.getH3IndexesFromUnidirectionalEdge(edgeIndex)](#module_h3.getH3IndexesFromUnidirectionalEdge) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
+    * [.getH3UnidirectionalEdgesFromHexagon(h3Index)](#module_h3.getH3UnidirectionalEdgesFromHexagon) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
+    * [.getH3UnidirectionalEdgeBoundary(edgeIndex, [formatAsGeoJson])](#module_h3.getH3UnidirectionalEdgeBoundary) ⇒ <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;number&gt;&gt;</code>
     * [.h3Distance(origin, destination)](#module_h3.h3Distance) ⇒ <code>number</code>
-    * [.h3Line(origin, destination)](#module_h3.h3Line) ⇒ <code>Array.&lt;H3Index&gt;</code>
+    * [.h3Line(origin, destination)](#module_h3.h3Line) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
     * [.experimentalH3ToLocalIj(origin, destination)](#module_h3.experimentalH3ToLocalIj) ⇒ <code>CoordIJ</code>
     * [.experimentalLocalIjToH3(origin, coords)](#module_h3.experimentalLocalIjToH3) ⇒ <code>H3Index</code>
     * [.pointDist(latlng1, latlng2, unit)](#module_h3.pointDist) ⇒ <code>number</code>
@@ -124,11 +124,12 @@ const coordinates = h3.h3SetToMultiPolygon(hexagons, true);
     * [.hexArea(res, unit)](#module_h3.hexArea) ⇒ <code>number</code>
     * [.edgeLength(res, unit)](#module_h3.edgeLength) ⇒ <code>number</code>
     * [.numHexagons(res)](#module_h3.numHexagons) ⇒ <code>number</code>
-    * [.getRes0Indexes()](#module_h3.getRes0Indexes) ⇒ <code>Array.&lt;H3Index&gt;</code>
-    * [.getPentagonIndexes(res)](#module_h3.getPentagonIndexes) ⇒ <code>Array.&lt;H3Index&gt;</code>
+    * [.getRes0Indexes()](#module_h3.getRes0Indexes) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
+    * [.getPentagonIndexes(res)](#module_h3.getPentagonIndexes) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
     * [.degsToRads(deg)](#module_h3.degsToRads) ⇒ <code>number</code>
     * [.radsToDegs(rad)](#module_h3.radsToDegs) ⇒ <code>number</code>
     * [.H3Index](#module_h3.H3Index) : <code>string</code>
+    * [.H3IndexInput](#module_h3.H3IndexInput) : <code>string</code> \| <code>Array.&lt;number&gt;</code>
     * [.CoordIJ](#module_h3.CoordIJ) : <code>Object</code>
     * [.UNITS](#module_h3.UNITS) : <code>Object</code>
 
@@ -144,7 +145,7 @@ Whether a given string represents a valid H3 index
 
 | Param | Type | Description |
 | --- | --- | --- |
-| h3Index | <code>H3Index</code> | H3 index to check |
+| h3Index | <code>H3IndexInput</code> | H3 index to check |
 
 
 * * *
@@ -158,7 +159,7 @@ Whether the given H3 index is a pentagon
 
 | Param | Type | Description |
 | --- | --- | --- |
-| h3Index | <code>H3Index</code> | H3 index to check |
+| h3Index | <code>H3IndexInput</code> | H3 index to check |
 
 
 * * *
@@ -174,7 +175,7 @@ icosahedron edges, making them not true hexagons).
 
 | Param | Type | Description |
 | --- | --- | --- |
-| h3Index | <code>H3Index</code> | H3 index to check |
+| h3Index | <code>H3IndexInput</code> | H3 index to check |
 
 
 * * *
@@ -188,21 +189,21 @@ Get the number of the base cell for a given H3 index
 
 | Param | Type | Description |
 | --- | --- | --- |
-| h3Index | <code>H3Index</code> | H3 index to get the base cell for |
+| h3Index | <code>H3IndexInput</code> | H3 index to get the base cell for |
 
 
 * * *
 
 <a name="module_h3.h3GetFaces"></a>
 
-### h3.h3GetFaces(h3Index) ⇒ <code>Array.&lt;number&gt;</code>
+### h3.h3GetFaces(h3Index) ⇒ <code>[ &#x27;Array&#x27; ].&lt;number&gt;</code>
 Get the indices of all icosahedron faces intersected by a given H3 index
 
-**Returns**: <code>Array.&lt;number&gt;</code> - Indices (0-19) of all intersected faces  
+**Returns**: <code>[ &#x27;Array&#x27; ].&lt;number&gt;</code> - Indices (0-19) of all intersected faces  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| h3Index | <code>H3Index</code> | H3 index to get faces for |
+| h3Index | <code>H3IndexInput</code> | H3 index to get faces for |
 
 
 * * *
@@ -216,7 +217,7 @@ Returns the resolution of an H3 index
 
 | Param | Type | Description |
 | --- | --- | --- |
-| h3Index | <code>H3Index</code> | H3 index to get resolution |
+| h3Index | <code>H3IndexInput</code> | H3 index to get resolution |
 
 
 * * *
@@ -239,26 +240,26 @@ Get the hexagon containing a lat,lon point
 
 <a name="module_h3.h3ToGeo"></a>
 
-### h3.h3ToGeo(h3Index) ⇒ <code>Array.&lt;number&gt;</code>
+### h3.h3ToGeo(h3Index) ⇒ <code>[ &#x27;Array&#x27; ].&lt;number&gt;</code>
 Get the lat,lon center of a given hexagon
 
-**Returns**: <code>Array.&lt;number&gt;</code> - Point as a [lat, lng] pair  
+**Returns**: <code>[ &#x27;Array&#x27; ].&lt;number&gt;</code> - Point as a [lat, lng] pair  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| h3Index | <code>H3Index</code> | H3 index |
+| h3Index | <code>H3IndexInput</code> | H3 index |
 
 
 * * *
 
 <a name="module_h3.h3ToGeoBoundary"></a>
 
-### h3.h3ToGeoBoundary(h3Index, [formatAsGeoJson]) ⇒ <code>Array.&lt;Array.&lt;number&gt;&gt;</code>
+### h3.h3ToGeoBoundary(h3Index, [formatAsGeoJson]) ⇒ <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;number&gt;&gt;</code>
 Get the vertices of a given hexagon (or pentagon), as an array of [lat, lng]
 points. For pentagons and hexagons on the edge of an icosahedron face, this
 function may return up to 10 vertices.
 
-**Returns**: <code>Array.&lt;Array.&lt;number&gt;&gt;</code> - Array of [lat, lng] pairs  
+**Returns**: <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;number&gt;&gt;</code> - Array of [lat, lng] pairs  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -277,7 +278,7 @@ Get the parent of the given hexagon at a particular resolution
 
 | Param | Type | Description |
 | --- | --- | --- |
-| h3Index | <code>H3Index</code> | H3 index to get parent for |
+| h3Index | <code>H3IndexInput</code> | H3 index to get parent for |
 | res | <code>number</code> | Resolution of hexagon to return |
 
 
@@ -285,14 +286,14 @@ Get the parent of the given hexagon at a particular resolution
 
 <a name="module_h3.h3ToChildren"></a>
 
-### h3.h3ToChildren(h3Index, res) ⇒ <code>Array.&lt;H3Index&gt;</code>
+### h3.h3ToChildren(h3Index, res) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
 Get the children/descendents of the given hexagon at a particular resolution
 
-**Returns**: <code>Array.&lt;H3Index&gt;</code> - H3 indexes of children, or empty array for invalid input  
+**Returns**: <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code> - H3 indexes of children, or empty array for invalid input  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| h3Index | <code>H3Index</code> | H3 index to get children for |
+| h3Index | <code>H3IndexInput</code> | H3 index to get children for |
 | res | <code>number</code> | Resolution of hexagons to return |
 
 
@@ -307,7 +308,7 @@ Get the center child of the given hexagon at a particular resolution
 
 | Param | Type | Description |
 | --- | --- | --- |
-| h3Index | <code>H3Index</code> | H3 index to get center child for |
+| h3Index | <code>H3IndexInput</code> | H3 index to get center child for |
 | res | <code>number</code> | Resolution of hexagon to return |
 
 
@@ -315,14 +316,14 @@ Get the center child of the given hexagon at a particular resolution
 
 <a name="module_h3.kRing"></a>
 
-### h3.kRing(h3Index, ringSize) ⇒ <code>Array.&lt;H3Index&gt;</code>
+### h3.kRing(h3Index, ringSize) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
 Get all hexagons in a k-ring around a given center. The order of the hexagons is undefined.
 
-**Returns**: <code>Array.&lt;H3Index&gt;</code> - H3 indexes for all hexagons in ring  
+**Returns**: <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code> - H3 indexes for all hexagons in ring  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| h3Index | <code>H3Index</code> | H3 index of center hexagon |
+| h3Index | <code>H3IndexInput</code> | H3 index of center hexagon |
 | ringSize | <code>number</code> | Radius of k-ring |
 
 
@@ -330,15 +331,15 @@ Get all hexagons in a k-ring around a given center. The order of the hexagons is
 
 <a name="module_h3.kRingDistances"></a>
 
-### h3.kRingDistances(h3Index, ringSize) ⇒ <code>Array.&lt;Array.&lt;H3Index&gt;&gt;</code>
+### h3.kRingDistances(h3Index, ringSize) ⇒ <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;H3Index&gt;&gt;</code>
 Get all hexagons in a k-ring around a given center, in an array of arrays
 ordered by distance from the origin. The order of the hexagons within each ring is undefined.
 
-**Returns**: <code>Array.&lt;Array.&lt;H3Index&gt;&gt;</code> - Array of arrays with H3 indexes for all hexagons each ring  
+**Returns**: <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;H3Index&gt;&gt;</code> - Array of arrays with H3 indexes for all hexagons each ring  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| h3Index | <code>H3Index</code> | H3 index of center hexagon |
+| h3Index | <code>H3IndexInput</code> | H3 index of center hexagon |
 | ringSize | <code>number</code> | Radius of k-ring |
 
 
@@ -346,11 +347,11 @@ ordered by distance from the origin. The order of the hexagons within each ring 
 
 <a name="module_h3.hexRing"></a>
 
-### h3.hexRing(h3Index, ringSize) ⇒ <code>Array.&lt;H3Index&gt;</code>
+### h3.hexRing(h3Index, ringSize) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
 Get all hexagons in a hollow hexagonal ring centered at origin with sides of a given length.
 Unlike kRing, this function will throw an error if there is a pentagon anywhere in the ring.
 
-**Returns**: <code>Array.&lt;H3Index&gt;</code> - H3 indexes for all hexagons in ring  
+**Returns**: <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code> - H3 indexes for all hexagons in ring  
 **Throws**:
 
 - <code>Error</code> If the algorithm could not calculate the ring
@@ -358,7 +359,7 @@ Unlike kRing, this function will throw an error if there is a pentagon anywhere 
 
 | Param | Type | Description |
 | --- | --- | --- |
-| h3Index | <code>H3Index</code> | H3 index of center hexagon |
+| h3Index | <code>H3IndexInput</code> | H3 index of center hexagon |
 | ringSize | <code>number</code> | Radius of ring |
 
 
@@ -366,14 +367,14 @@ Unlike kRing, this function will throw an error if there is a pentagon anywhere 
 
 <a name="module_h3.polyfill"></a>
 
-### h3.polyfill(coordinates, res, [isGeoJson]) ⇒ <code>Array.&lt;H3Index&gt;</code>
+### h3.polyfill(coordinates, res, [isGeoJson]) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
 Get all hexagons with centers contained in a given polygon. The polygon
 is specified with GeoJson semantics as an array of loops. Each loop is
 an array of [lat, lng] pairs (or [lng, lat] if isGeoJson is specified).
 The first loop is the perimeter of the polygon, and subsequent loops are
 expected to be holes.
 
-**Returns**: <code>Array.&lt;H3Index&gt;</code> - H3 indexes for all hexagons in polygon  
+**Returns**: <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code> - H3 indexes for all hexagons in polygon  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -386,17 +387,17 @@ expected to be holes.
 
 <a name="module_h3.h3SetToMultiPolygon"></a>
 
-### h3.h3SetToMultiPolygon(h3Indexes, [formatAsGeoJson]) ⇒ <code>Array.&lt;Array.&lt;Array.&lt;Array.&lt;number&gt;&gt;&gt;&gt;</code>
+### h3.h3SetToMultiPolygon(h3Indexes, [formatAsGeoJson]) ⇒ <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;Array.&lt;Array.&lt;number&gt;&gt;&gt;&gt;</code>
 Get the outlines of a set of H3 hexagons, returned in GeoJSON MultiPolygon
 format (an array of polygons, each with an array of loops, each an array of
 coordinates). Coordinates are returned as [lat, lng] pairs unless GeoJSON
 is requested.
 
-**Returns**: <code>Array.&lt;Array.&lt;Array.&lt;Array.&lt;number&gt;&gt;&gt;&gt;</code> - MultiPolygon-style output.  
+**Returns**: <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;Array.&lt;Array.&lt;number&gt;&gt;&gt;&gt;</code> - MultiPolygon-style output.  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| h3Indexes | <code>Array.&lt;H3Index&gt;</code> | H3 indexes to get outlines for |
+| h3Indexes | <code>[ &#x27;Array&#x27; ].&lt;H3IndexInput&gt;</code> | H3 indexes to get outlines for |
 | [formatAsGeoJson] | <code>boolean</code> | Whether to provide GeoJSON output:                                    [lng, lat], closed loops |
 
 
@@ -404,11 +405,11 @@ is requested.
 
 <a name="module_h3.compact"></a>
 
-### h3.compact(h3Set) ⇒ <code>Array.&lt;H3Index&gt;</code>
+### h3.compact(h3Set) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
 Compact a set of hexagons of the same resolution into a set of hexagons across
 multiple levels that represents the same area.
 
-**Returns**: <code>Array.&lt;H3Index&gt;</code> - Compacted H3 indexes  
+**Returns**: <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code> - Compacted H3 indexes  
 **Throws**:
 
 - <code>Error</code> If the input is invalid (e.g. duplicate hexagons)
@@ -416,17 +417,17 @@ multiple levels that represents the same area.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| h3Set | <code>Array.&lt;H3Index&gt;</code> | H3 indexes to compact |
+| h3Set | <code>[ &#x27;Array&#x27; ].&lt;H3IndexInput&gt;</code> | H3 indexes to compact |
 
 
 * * *
 
 <a name="module_h3.uncompact"></a>
 
-### h3.uncompact(compactedSet, res) ⇒ <code>Array.&lt;H3Index&gt;</code>
+### h3.uncompact(compactedSet, res) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
 Uncompact a compacted set of hexagons to hexagons of the same resolution
 
-**Returns**: <code>Array.&lt;H3Index&gt;</code> - The uncompacted H3 indexes  
+**Returns**: <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code> - The uncompacted H3 indexes  
 **Throws**:
 
 - <code>Error</code> If the input is invalid (e.g. invalid resolution)
@@ -434,7 +435,7 @@ Uncompact a compacted set of hexagons to hexagons of the same resolution
 
 | Param | Type | Description |
 | --- | --- | --- |
-| compactedSet | <code>Array.&lt;H3Index&gt;</code> | H3 indexes to uncompact |
+| compactedSet | <code>[ &#x27;Array&#x27; ].&lt;H3IndexInput&gt;</code> | H3 indexes to uncompact |
 | res | <code>number</code> | The resolution to uncompact to |
 
 
@@ -449,8 +450,8 @@ Whether two H3 indexes are neighbors (share an edge)
 
 | Param | Type | Description |
 | --- | --- | --- |
-| origin | <code>H3Index</code> | Origin hexagon index |
-| destination | <code>H3Index</code> | Destination hexagon index |
+| origin | <code>H3IndexInput</code> | Origin hexagon index |
+| destination | <code>H3IndexInput</code> | Destination hexagon index |
 
 
 * * *
@@ -464,8 +465,8 @@ Get an H3 index representing a unidirectional edge for a given origin and destin
 
 | Param | Type | Description |
 | --- | --- | --- |
-| origin | <code>H3Index</code> | Origin hexagon index |
-| destination | <code>H3Index</code> | Destination hexagon index |
+| origin | <code>H3IndexInput</code> | Origin hexagon index |
+| destination | <code>H3IndexInput</code> | Destination hexagon index |
 
 
 * * *
@@ -479,7 +480,7 @@ Get the origin hexagon from an H3 index representing a unidirectional edge
 
 | Param | Type | Description |
 | --- | --- | --- |
-| edgeIndex | <code>H3Index</code> | H3 index of the edge |
+| edgeIndex | <code>H3IndexInput</code> | H3 index of the edge |
 
 
 * * *
@@ -493,7 +494,7 @@ Get the destination hexagon from an H3 index representing a unidirectional edge
 
 | Param | Type | Description |
 | --- | --- | --- |
-| edgeIndex | <code>H3Index</code> | H3 index of the edge |
+| edgeIndex | <code>H3IndexInput</code> | H3 index of the edge |
 
 
 * * *
@@ -507,51 +508,51 @@ Whether the input is a valid unidirectional edge
 
 | Param | Type | Description |
 | --- | --- | --- |
-| edgeIndex | <code>H3Index</code> | H3 index of the edge |
+| edgeIndex | <code>H3IndexInput</code> | H3 index of the edge |
 
 
 * * *
 
 <a name="module_h3.getH3IndexesFromUnidirectionalEdge"></a>
 
-### h3.getH3IndexesFromUnidirectionalEdge(edgeIndex) ⇒ <code>Array.&lt;H3Index&gt;</code>
+### h3.getH3IndexesFromUnidirectionalEdge(edgeIndex) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
 Get the [origin, destination] pair represented by a unidirectional edge
 
-**Returns**: <code>Array.&lt;H3Index&gt;</code> - [origin, destination] pair as H3 indexes  
+**Returns**: <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code> - [origin, destination] pair as H3 indexes  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| edgeIndex | <code>H3Index</code> | H3 index of the edge |
+| edgeIndex | <code>H3IndexInput</code> | H3 index of the edge |
 
 
 * * *
 
 <a name="module_h3.getH3UnidirectionalEdgesFromHexagon"></a>
 
-### h3.getH3UnidirectionalEdgesFromHexagon(h3Index) ⇒ <code>Array.&lt;H3Index&gt;</code>
+### h3.getH3UnidirectionalEdgesFromHexagon(h3Index) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
 Get all of the unidirectional edges with the given H3 index as the origin (i.e. an edge to
 every neighbor)
 
-**Returns**: <code>Array.&lt;H3Index&gt;</code> - List of unidirectional edges  
+**Returns**: <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code> - List of unidirectional edges  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| h3Index | <code>H3Index</code> | H3 index of the origin hexagon |
+| h3Index | <code>H3IndexInput</code> | H3 index of the origin hexagon |
 
 
 * * *
 
 <a name="module_h3.getH3UnidirectionalEdgeBoundary"></a>
 
-### h3.getH3UnidirectionalEdgeBoundary(edgeIndex, [formatAsGeoJson]) ⇒ <code>Array.&lt;Array.&lt;number&gt;&gt;</code>
+### h3.getH3UnidirectionalEdgeBoundary(edgeIndex, [formatAsGeoJson]) ⇒ <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;number&gt;&gt;</code>
 Get the vertices of a given edge as an array of [lat, lng] points. Note that for edges that
 cross the edge of an icosahedron face, this may return 3 coordinates.
 
-**Returns**: <code>Array.&lt;Array.&lt;number&gt;&gt;</code> - Array of geo coordinate pairs  
+**Returns**: <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;number&gt;&gt;</code> - Array of geo coordinate pairs  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| edgeIndex | <code>H3Index</code> | H3 index of the edge |
+| edgeIndex | <code>H3IndexInput</code> | H3 index of the edge |
 | [formatAsGeoJson] | <code>boolean</code> | Whether to provide GeoJSON output: [lng, lat] |
 
 
@@ -569,15 +570,15 @@ on opposite sides of a pentagon.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| origin | <code>H3Index</code> | Origin hexagon index |
-| destination | <code>H3Index</code> | Destination hexagon index |
+| origin | <code>H3IndexInput</code> | Origin hexagon index |
+| destination | <code>H3IndexInput</code> | Destination hexagon index |
 
 
 * * *
 
 <a name="module_h3.h3Line"></a>
 
-### h3.h3Line(origin, destination) ⇒ <code>Array.&lt;H3Index&gt;</code>
+### h3.h3Line(origin, destination) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
 Given two H3 indexes, return the line of indexes between them (inclusive).
 
 This function may fail to find the line between two indexes, for
@@ -593,7 +594,7 @@ Notes:
  - Lines are drawn in grid space, and may not correspond exactly to either
    Cartesian lines or great arcs.
 
-**Returns**: <code>Array.&lt;H3Index&gt;</code> - H3 indexes connecting origin and destination  
+**Returns**: <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code> - H3 indexes connecting origin and destination  
 **Throws**:
 
 - <code>Error</code> If the line cannot be calculated
@@ -601,8 +602,8 @@ Notes:
 
 | Param | Type | Description |
 | --- | --- | --- |
-| origin | <code>H3Index</code> | Origin hexagon index |
-| destination | <code>H3Index</code> | Destination hexagon index |
+| origin | <code>H3IndexInput</code> | Origin hexagon index |
+| destination | <code>H3IndexInput</code> | Destination hexagon index |
 
 
 * * *
@@ -629,8 +630,8 @@ to be compatible across different versions of H3.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| origin | <code>H3Index</code> | Origin H3 index |
-| destination | <code>H3Index</code> | H3 index for which to find relative coordinates |
+| origin | <code>H3IndexInput</code> | Origin H3 index |
+| destination | <code>H3IndexInput</code> | H3 index for which to find relative coordinates |
 
 
 * * *
@@ -657,7 +658,7 @@ to be compatible across different versions of H3.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| origin | <code>H3Index</code> | Origin H3 index |
+| origin | <code>H3IndexInput</code> | Origin H3 index |
 | coords | <code>CoordIJ</code> | Coordinates as an `{i, j}` pair |
 
 
@@ -778,21 +779,21 @@ so consumers should use caution when applying further operations to the output.
 
 <a name="module_h3.getRes0Indexes"></a>
 
-### h3.getRes0Indexes() ⇒ <code>Array.&lt;H3Index&gt;</code>
+### h3.getRes0Indexes() ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
 Get all H3 indexes at resolution 0. As every index at every resolution > 0 is
 the descendant of a res 0 index, this can be used with h3ToChildren to iterate
 over H3 indexes at any resolution.
 
-**Returns**: <code>Array.&lt;H3Index&gt;</code> - All H3 indexes at res 0  
+**Returns**: <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code> - All H3 indexes at res 0  
 
 * * *
 
 <a name="module_h3.getPentagonIndexes"></a>
 
-### h3.getPentagonIndexes(res) ⇒ <code>Array.&lt;H3Index&gt;</code>
+### h3.getPentagonIndexes(res) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
 Get the twelve pentagon indexes at a given resolution.
 
-**Returns**: <code>Array.&lt;H3Index&gt;</code> - All H3 pentagon indexes at res  
+**Returns**: <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code> - All H3 pentagon indexes at res  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -833,6 +834,15 @@ Convert radians to degrees
 
 ### h3.H3Index : <code>string</code>
 64-bit hexidecimal string representation of an H3 index
+
+
+* * *
+
+<a name="module_h3.H3IndexInput"></a>
+
+### h3.H3IndexInput : <code>string</code> \| <code>Array.&lt;number&gt;</code>
+64-bit hexidecimal string representation of an H3 index,
+or two 32-bit integers in little endian order in an array.
 
 
 * * *

--- a/README.md
+++ b/README.md
@@ -91,31 +91,31 @@ const coordinates = h3.h3SetToMultiPolygon(hexagons, true);
     * [.h3IsPentagon(h3Index)](#module_h3.h3IsPentagon) ⇒ <code>boolean</code>
     * [.h3IsResClassIII(h3Index)](#module_h3.h3IsResClassIII) ⇒ <code>boolean</code>
     * [.h3GetBaseCell(h3Index)](#module_h3.h3GetBaseCell) ⇒ <code>number</code>
-    * [.h3GetFaces(h3Index)](#module_h3.h3GetFaces) ⇒ <code>[ &#x27;Array&#x27; ].&lt;number&gt;</code>
+    * [.h3GetFaces(h3Index)](#module_h3.h3GetFaces) ⇒ <code>Array.&lt;number&gt;</code>
     * [.h3GetResolution(h3Index)](#module_h3.h3GetResolution) ⇒ <code>number</code>
     * [.geoToH3(lat, lng, res)](#module_h3.geoToH3) ⇒ <code>H3Index</code>
-    * [.h3ToGeo(h3Index)](#module_h3.h3ToGeo) ⇒ <code>[ &#x27;Array&#x27; ].&lt;number&gt;</code>
-    * [.h3ToGeoBoundary(h3Index, [formatAsGeoJson])](#module_h3.h3ToGeoBoundary) ⇒ <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;number&gt;&gt;</code>
+    * [.h3ToGeo(h3Index)](#module_h3.h3ToGeo) ⇒ <code>Array.&lt;number&gt;</code>
+    * [.h3ToGeoBoundary(h3Index, [formatAsGeoJson])](#module_h3.h3ToGeoBoundary) ⇒ <code>Array.&lt;Array.&lt;number&gt;&gt;</code>
     * [.h3ToParent(h3Index, res)](#module_h3.h3ToParent) ⇒ <code>H3Index</code>
-    * [.h3ToChildren(h3Index, res)](#module_h3.h3ToChildren) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
+    * [.h3ToChildren(h3Index, res)](#module_h3.h3ToChildren) ⇒ <code>Array.&lt;H3Index&gt;</code>
     * [.h3ToCenterChild(h3Index, res)](#module_h3.h3ToCenterChild) ⇒ <code>H3Index</code>
-    * [.kRing(h3Index, ringSize)](#module_h3.kRing) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
-    * [.kRingDistances(h3Index, ringSize)](#module_h3.kRingDistances) ⇒ <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;H3Index&gt;&gt;</code>
-    * [.hexRing(h3Index, ringSize)](#module_h3.hexRing) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
-    * [.polyfill(coordinates, res, [isGeoJson])](#module_h3.polyfill) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
-    * [.h3SetToMultiPolygon(h3Indexes, [formatAsGeoJson])](#module_h3.h3SetToMultiPolygon) ⇒ <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;Array.&lt;Array.&lt;number&gt;&gt;&gt;&gt;</code>
-    * [.compact(h3Set)](#module_h3.compact) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
-    * [.uncompact(compactedSet, res)](#module_h3.uncompact) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
+    * [.kRing(h3Index, ringSize)](#module_h3.kRing) ⇒ <code>Array.&lt;H3Index&gt;</code>
+    * [.kRingDistances(h3Index, ringSize)](#module_h3.kRingDistances) ⇒ <code>Array.&lt;Array.&lt;H3Index&gt;&gt;</code>
+    * [.hexRing(h3Index, ringSize)](#module_h3.hexRing) ⇒ <code>Array.&lt;H3Index&gt;</code>
+    * [.polyfill(coordinates, res, [isGeoJson])](#module_h3.polyfill) ⇒ <code>Array.&lt;H3Index&gt;</code>
+    * [.h3SetToMultiPolygon(h3Indexes, [formatAsGeoJson])](#module_h3.h3SetToMultiPolygon) ⇒ <code>Array.&lt;Array.&lt;Array.&lt;Array.&lt;number&gt;&gt;&gt;&gt;</code>
+    * [.compact(h3Set)](#module_h3.compact) ⇒ <code>Array.&lt;H3Index&gt;</code>
+    * [.uncompact(compactedSet, res)](#module_h3.uncompact) ⇒ <code>Array.&lt;H3Index&gt;</code>
     * [.h3IndexesAreNeighbors(origin, destination)](#module_h3.h3IndexesAreNeighbors) ⇒ <code>boolean</code>
     * [.getH3UnidirectionalEdge(origin, destination)](#module_h3.getH3UnidirectionalEdge) ⇒ <code>H3Index</code>
     * [.getOriginH3IndexFromUnidirectionalEdge(edgeIndex)](#module_h3.getOriginH3IndexFromUnidirectionalEdge) ⇒ <code>H3Index</code>
     * [.getDestinationH3IndexFromUnidirectionalEdge(edgeIndex)](#module_h3.getDestinationH3IndexFromUnidirectionalEdge) ⇒ <code>H3Index</code>
     * [.h3UnidirectionalEdgeIsValid(edgeIndex)](#module_h3.h3UnidirectionalEdgeIsValid) ⇒ <code>boolean</code>
-    * [.getH3IndexesFromUnidirectionalEdge(edgeIndex)](#module_h3.getH3IndexesFromUnidirectionalEdge) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
-    * [.getH3UnidirectionalEdgesFromHexagon(h3Index)](#module_h3.getH3UnidirectionalEdgesFromHexagon) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
-    * [.getH3UnidirectionalEdgeBoundary(edgeIndex, [formatAsGeoJson])](#module_h3.getH3UnidirectionalEdgeBoundary) ⇒ <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;number&gt;&gt;</code>
+    * [.getH3IndexesFromUnidirectionalEdge(edgeIndex)](#module_h3.getH3IndexesFromUnidirectionalEdge) ⇒ <code>Array.&lt;H3Index&gt;</code>
+    * [.getH3UnidirectionalEdgesFromHexagon(h3Index)](#module_h3.getH3UnidirectionalEdgesFromHexagon) ⇒ <code>Array.&lt;H3Index&gt;</code>
+    * [.getH3UnidirectionalEdgeBoundary(edgeIndex, [formatAsGeoJson])](#module_h3.getH3UnidirectionalEdgeBoundary) ⇒ <code>Array.&lt;Array.&lt;number&gt;&gt;</code>
     * [.h3Distance(origin, destination)](#module_h3.h3Distance) ⇒ <code>number</code>
-    * [.h3Line(origin, destination)](#module_h3.h3Line) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
+    * [.h3Line(origin, destination)](#module_h3.h3Line) ⇒ <code>Array.&lt;H3Index&gt;</code>
     * [.experimentalH3ToLocalIj(origin, destination)](#module_h3.experimentalH3ToLocalIj) ⇒ <code>CoordIJ</code>
     * [.experimentalLocalIjToH3(origin, coords)](#module_h3.experimentalLocalIjToH3) ⇒ <code>H3Index</code>
     * [.pointDist(latlng1, latlng2, unit)](#module_h3.pointDist) ⇒ <code>number</code>
@@ -124,8 +124,8 @@ const coordinates = h3.h3SetToMultiPolygon(hexagons, true);
     * [.hexArea(res, unit)](#module_h3.hexArea) ⇒ <code>number</code>
     * [.edgeLength(res, unit)](#module_h3.edgeLength) ⇒ <code>number</code>
     * [.numHexagons(res)](#module_h3.numHexagons) ⇒ <code>number</code>
-    * [.getRes0Indexes()](#module_h3.getRes0Indexes) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
-    * [.getPentagonIndexes(res)](#module_h3.getPentagonIndexes) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
+    * [.getRes0Indexes()](#module_h3.getRes0Indexes) ⇒ <code>Array.&lt;H3Index&gt;</code>
+    * [.getPentagonIndexes(res)](#module_h3.getPentagonIndexes) ⇒ <code>Array.&lt;H3Index&gt;</code>
     * [.degsToRads(deg)](#module_h3.degsToRads) ⇒ <code>number</code>
     * [.radsToDegs(rad)](#module_h3.radsToDegs) ⇒ <code>number</code>
     * [.H3Index](#module_h3.H3Index) : <code>string</code>
@@ -196,10 +196,10 @@ Get the number of the base cell for a given H3 index
 
 <a name="module_h3.h3GetFaces"></a>
 
-### h3.h3GetFaces(h3Index) ⇒ <code>[ &#x27;Array&#x27; ].&lt;number&gt;</code>
+### h3.h3GetFaces(h3Index) ⇒ <code>Array.&lt;number&gt;</code>
 Get the indices of all icosahedron faces intersected by a given H3 index
 
-**Returns**: <code>[ &#x27;Array&#x27; ].&lt;number&gt;</code> - Indices (0-19) of all intersected faces  
+**Returns**: <code>Array.&lt;number&gt;</code> - Indices (0-19) of all intersected faces  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -240,10 +240,10 @@ Get the hexagon containing a lat,lon point
 
 <a name="module_h3.h3ToGeo"></a>
 
-### h3.h3ToGeo(h3Index) ⇒ <code>[ &#x27;Array&#x27; ].&lt;number&gt;</code>
+### h3.h3ToGeo(h3Index) ⇒ <code>Array.&lt;number&gt;</code>
 Get the lat,lon center of a given hexagon
 
-**Returns**: <code>[ &#x27;Array&#x27; ].&lt;number&gt;</code> - Point as a [lat, lng] pair  
+**Returns**: <code>Array.&lt;number&gt;</code> - Point as a [lat, lng] pair  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -254,12 +254,12 @@ Get the lat,lon center of a given hexagon
 
 <a name="module_h3.h3ToGeoBoundary"></a>
 
-### h3.h3ToGeoBoundary(h3Index, [formatAsGeoJson]) ⇒ <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;number&gt;&gt;</code>
+### h3.h3ToGeoBoundary(h3Index, [formatAsGeoJson]) ⇒ <code>Array.&lt;Array.&lt;number&gt;&gt;</code>
 Get the vertices of a given hexagon (or pentagon), as an array of [lat, lng]
 points. For pentagons and hexagons on the edge of an icosahedron face, this
 function may return up to 10 vertices.
 
-**Returns**: <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;number&gt;&gt;</code> - Array of [lat, lng] pairs  
+**Returns**: <code>Array.&lt;Array.&lt;number&gt;&gt;</code> - Array of [lat, lng] pairs  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -286,10 +286,10 @@ Get the parent of the given hexagon at a particular resolution
 
 <a name="module_h3.h3ToChildren"></a>
 
-### h3.h3ToChildren(h3Index, res) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
+### h3.h3ToChildren(h3Index, res) ⇒ <code>Array.&lt;H3Index&gt;</code>
 Get the children/descendents of the given hexagon at a particular resolution
 
-**Returns**: <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code> - H3 indexes of children, or empty array for invalid input  
+**Returns**: <code>Array.&lt;H3Index&gt;</code> - H3 indexes of children, or empty array for invalid input  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -316,10 +316,10 @@ Get the center child of the given hexagon at a particular resolution
 
 <a name="module_h3.kRing"></a>
 
-### h3.kRing(h3Index, ringSize) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
+### h3.kRing(h3Index, ringSize) ⇒ <code>Array.&lt;H3Index&gt;</code>
 Get all hexagons in a k-ring around a given center. The order of the hexagons is undefined.
 
-**Returns**: <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code> - H3 indexes for all hexagons in ring  
+**Returns**: <code>Array.&lt;H3Index&gt;</code> - H3 indexes for all hexagons in ring  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -331,11 +331,11 @@ Get all hexagons in a k-ring around a given center. The order of the hexagons is
 
 <a name="module_h3.kRingDistances"></a>
 
-### h3.kRingDistances(h3Index, ringSize) ⇒ <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;H3Index&gt;&gt;</code>
+### h3.kRingDistances(h3Index, ringSize) ⇒ <code>Array.&lt;Array.&lt;H3Index&gt;&gt;</code>
 Get all hexagons in a k-ring around a given center, in an array of arrays
 ordered by distance from the origin. The order of the hexagons within each ring is undefined.
 
-**Returns**: <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;H3Index&gt;&gt;</code> - Array of arrays with H3 indexes for all hexagons each ring  
+**Returns**: <code>Array.&lt;Array.&lt;H3Index&gt;&gt;</code> - Array of arrays with H3 indexes for all hexagons each ring  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -347,11 +347,11 @@ ordered by distance from the origin. The order of the hexagons within each ring 
 
 <a name="module_h3.hexRing"></a>
 
-### h3.hexRing(h3Index, ringSize) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
+### h3.hexRing(h3Index, ringSize) ⇒ <code>Array.&lt;H3Index&gt;</code>
 Get all hexagons in a hollow hexagonal ring centered at origin with sides of a given length.
 Unlike kRing, this function will throw an error if there is a pentagon anywhere in the ring.
 
-**Returns**: <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code> - H3 indexes for all hexagons in ring  
+**Returns**: <code>Array.&lt;H3Index&gt;</code> - H3 indexes for all hexagons in ring  
 **Throws**:
 
 - <code>Error</code> If the algorithm could not calculate the ring
@@ -367,14 +367,14 @@ Unlike kRing, this function will throw an error if there is a pentagon anywhere 
 
 <a name="module_h3.polyfill"></a>
 
-### h3.polyfill(coordinates, res, [isGeoJson]) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
+### h3.polyfill(coordinates, res, [isGeoJson]) ⇒ <code>Array.&lt;H3Index&gt;</code>
 Get all hexagons with centers contained in a given polygon. The polygon
 is specified with GeoJson semantics as an array of loops. Each loop is
 an array of [lat, lng] pairs (or [lng, lat] if isGeoJson is specified).
 The first loop is the perimeter of the polygon, and subsequent loops are
 expected to be holes.
 
-**Returns**: <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code> - H3 indexes for all hexagons in polygon  
+**Returns**: <code>Array.&lt;H3Index&gt;</code> - H3 indexes for all hexagons in polygon  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -387,17 +387,17 @@ expected to be holes.
 
 <a name="module_h3.h3SetToMultiPolygon"></a>
 
-### h3.h3SetToMultiPolygon(h3Indexes, [formatAsGeoJson]) ⇒ <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;Array.&lt;Array.&lt;number&gt;&gt;&gt;&gt;</code>
+### h3.h3SetToMultiPolygon(h3Indexes, [formatAsGeoJson]) ⇒ <code>Array.&lt;Array.&lt;Array.&lt;Array.&lt;number&gt;&gt;&gt;&gt;</code>
 Get the outlines of a set of H3 hexagons, returned in GeoJSON MultiPolygon
 format (an array of polygons, each with an array of loops, each an array of
 coordinates). Coordinates are returned as [lat, lng] pairs unless GeoJSON
 is requested.
 
-**Returns**: <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;Array.&lt;Array.&lt;number&gt;&gt;&gt;&gt;</code> - MultiPolygon-style output.  
+**Returns**: <code>Array.&lt;Array.&lt;Array.&lt;Array.&lt;number&gt;&gt;&gt;&gt;</code> - MultiPolygon-style output.  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| h3Indexes | <code>[ &#x27;Array&#x27; ].&lt;H3IndexInput&gt;</code> | H3 indexes to get outlines for |
+| h3Indexes | <code>Array.&lt;H3IndexInput&gt;</code> | H3 indexes to get outlines for |
 | [formatAsGeoJson] | <code>boolean</code> | Whether to provide GeoJSON output:                                    [lng, lat], closed loops |
 
 
@@ -405,11 +405,11 @@ is requested.
 
 <a name="module_h3.compact"></a>
 
-### h3.compact(h3Set) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
+### h3.compact(h3Set) ⇒ <code>Array.&lt;H3Index&gt;</code>
 Compact a set of hexagons of the same resolution into a set of hexagons across
 multiple levels that represents the same area.
 
-**Returns**: <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code> - Compacted H3 indexes  
+**Returns**: <code>Array.&lt;H3Index&gt;</code> - Compacted H3 indexes  
 **Throws**:
 
 - <code>Error</code> If the input is invalid (e.g. duplicate hexagons)
@@ -417,17 +417,17 @@ multiple levels that represents the same area.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| h3Set | <code>[ &#x27;Array&#x27; ].&lt;H3IndexInput&gt;</code> | H3 indexes to compact |
+| h3Set | <code>Array.&lt;H3IndexInput&gt;</code> | H3 indexes to compact |
 
 
 * * *
 
 <a name="module_h3.uncompact"></a>
 
-### h3.uncompact(compactedSet, res) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
+### h3.uncompact(compactedSet, res) ⇒ <code>Array.&lt;H3Index&gt;</code>
 Uncompact a compacted set of hexagons to hexagons of the same resolution
 
-**Returns**: <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code> - The uncompacted H3 indexes  
+**Returns**: <code>Array.&lt;H3Index&gt;</code> - The uncompacted H3 indexes  
 **Throws**:
 
 - <code>Error</code> If the input is invalid (e.g. invalid resolution)
@@ -435,7 +435,7 @@ Uncompact a compacted set of hexagons to hexagons of the same resolution
 
 | Param | Type | Description |
 | --- | --- | --- |
-| compactedSet | <code>[ &#x27;Array&#x27; ].&lt;H3IndexInput&gt;</code> | H3 indexes to uncompact |
+| compactedSet | <code>Array.&lt;H3IndexInput&gt;</code> | H3 indexes to uncompact |
 | res | <code>number</code> | The resolution to uncompact to |
 
 
@@ -515,10 +515,10 @@ Whether the input is a valid unidirectional edge
 
 <a name="module_h3.getH3IndexesFromUnidirectionalEdge"></a>
 
-### h3.getH3IndexesFromUnidirectionalEdge(edgeIndex) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
+### h3.getH3IndexesFromUnidirectionalEdge(edgeIndex) ⇒ <code>Array.&lt;H3Index&gt;</code>
 Get the [origin, destination] pair represented by a unidirectional edge
 
-**Returns**: <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code> - [origin, destination] pair as H3 indexes  
+**Returns**: <code>Array.&lt;H3Index&gt;</code> - [origin, destination] pair as H3 indexes  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -529,11 +529,11 @@ Get the [origin, destination] pair represented by a unidirectional edge
 
 <a name="module_h3.getH3UnidirectionalEdgesFromHexagon"></a>
 
-### h3.getH3UnidirectionalEdgesFromHexagon(h3Index) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
+### h3.getH3UnidirectionalEdgesFromHexagon(h3Index) ⇒ <code>Array.&lt;H3Index&gt;</code>
 Get all of the unidirectional edges with the given H3 index as the origin (i.e. an edge to
 every neighbor)
 
-**Returns**: <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code> - List of unidirectional edges  
+**Returns**: <code>Array.&lt;H3Index&gt;</code> - List of unidirectional edges  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -544,11 +544,11 @@ every neighbor)
 
 <a name="module_h3.getH3UnidirectionalEdgeBoundary"></a>
 
-### h3.getH3UnidirectionalEdgeBoundary(edgeIndex, [formatAsGeoJson]) ⇒ <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;number&gt;&gt;</code>
+### h3.getH3UnidirectionalEdgeBoundary(edgeIndex, [formatAsGeoJson]) ⇒ <code>Array.&lt;Array.&lt;number&gt;&gt;</code>
 Get the vertices of a given edge as an array of [lat, lng] points. Note that for edges that
 cross the edge of an icosahedron face, this may return 3 coordinates.
 
-**Returns**: <code>[ &#x27;Array&#x27; ].&lt;Array.&lt;number&gt;&gt;</code> - Array of geo coordinate pairs  
+**Returns**: <code>Array.&lt;Array.&lt;number&gt;&gt;</code> - Array of geo coordinate pairs  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -578,7 +578,7 @@ on opposite sides of a pentagon.
 
 <a name="module_h3.h3Line"></a>
 
-### h3.h3Line(origin, destination) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
+### h3.h3Line(origin, destination) ⇒ <code>Array.&lt;H3Index&gt;</code>
 Given two H3 indexes, return the line of indexes between them (inclusive).
 
 This function may fail to find the line between two indexes, for
@@ -594,7 +594,7 @@ Notes:
  - Lines are drawn in grid space, and may not correspond exactly to either
    Cartesian lines or great arcs.
 
-**Returns**: <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code> - H3 indexes connecting origin and destination  
+**Returns**: <code>Array.&lt;H3Index&gt;</code> - H3 indexes connecting origin and destination  
 **Throws**:
 
 - <code>Error</code> If the line cannot be calculated
@@ -779,21 +779,21 @@ so consumers should use caution when applying further operations to the output.
 
 <a name="module_h3.getRes0Indexes"></a>
 
-### h3.getRes0Indexes() ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
+### h3.getRes0Indexes() ⇒ <code>Array.&lt;H3Index&gt;</code>
 Get all H3 indexes at resolution 0. As every index at every resolution > 0 is
 the descendant of a res 0 index, this can be used with h3ToChildren to iterate
 over H3 indexes at any resolution.
 
-**Returns**: <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code> - All H3 indexes at res 0  
+**Returns**: <code>Array.&lt;H3Index&gt;</code> - All H3 indexes at res 0  
 
 * * *
 
 <a name="module_h3.getPentagonIndexes"></a>
 
-### h3.getPentagonIndexes(res) ⇒ <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code>
+### h3.getPentagonIndexes(res) ⇒ <code>Array.&lt;H3Index&gt;</code>
 Get the twelve pentagon indexes at a given resolution.
 
-**Returns**: <code>[ &#x27;Array&#x27; ].&lt;H3Index&gt;</code> - All H3 pentagon indexes at res  
+**Returns**: <code>Array.&lt;H3Index&gt;</code> - All H3 pentagon indexes at res  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/lib/h3core.js
+++ b/lib/h3core.js
@@ -55,6 +55,13 @@ const SZ_COORDIJ = H3.sizeOfCoordIJ();
  */
 
 /**
+ * 64-bit hexidecimal string representation of an H3 index,
+ * or two 32-bit integers in little endian order in an array.
+ * @static
+ * @typedef {H3Index | number[]} H3IndexInput
+ */
+
+/**
  * Coordinates as an `{i, j}` pair
  * @static
  * @typedef CoordIJ
@@ -107,10 +114,13 @@ const INVALID_HEXIDECIMAL_CHAR = /[^0-9a-fA-F]/;
 /**
  * Convert an H3 index (64-bit hexidecimal string) into a "split long" - a pair of 32-bit ints
  * @private
- * @param  {H3Index} h3Index  H3 index to check
+ * @param  {H3IndexInput} h3Index  H3 index to check
  * @return {number[]}         A two-element array with 32 lower bits and 32 upper bits
  */
 function h3IndexToSplitLong(h3Index) {
+    if (Array.isArray(h3Index) && Number.isInteger(h3Index[0]) && Number.isInteger(h3Index[1])) {
+        return h3Index;
+    }
     if (typeof h3Index !== 'string' || INVALID_HEXIDECIMAL_CHAR.test(h3Index)) {
         return [0, 0];
     }
@@ -290,7 +300,7 @@ function readH3IndexFromPointer(cAddress, offset = 0) {
  * Store an H3 index in C memory. Primarily used as an efficient way to
  * write sets of hexagons.
  * @private
- * @param  {H3Index} h3Index  H3 index to store
+ * @param  {H3IndexInput} h3Index  H3 index to store
  * @param  {number} cAddress  Pointer to allocated C memory
  * @param {number} offset     Offset, in number of H3 indexes from beginning
  *                            of the current array
@@ -329,7 +339,7 @@ function readArrayOfHexagons(cAddress, maxCount) {
  * Store an array of H3 index strings as a C array of 64-bit integers.
  * @private
  * @param  {number} cAddress    Pointer to C input array
- * @param  {H3Index[]} hexagons H3 indexes to pass to the C lib
+ * @param  {H3IndexInput[]} hexagons H3 indexes to pass to the C lib
  */
 function storeArrayOfHexagons(cAddress, hexagons) {
     // Assuming the cAddress points to an already appropriately
@@ -493,7 +503,7 @@ function readArrayOfPositiveIntegers(cAddress, count) {
 /**
  * Whether a given string represents a valid H3 index
  * @static
- * @param  {H3Index} h3Index  H3 index to check
+ * @param  {H3IndexInput} h3Index  H3 index to check
  * @return {boolean}          Whether the index is valid
  */
 export function h3IsValid(h3Index) {
@@ -504,7 +514,7 @@ export function h3IsValid(h3Index) {
 /**
  * Whether the given H3 index is a pentagon
  * @static
- * @param  {H3Index} h3Index  H3 index to check
+ * @param  {H3IndexInput} h3Index  H3 index to check
  * @return {boolean}          isPentagon
  */
 export function h3IsPentagon(h3Index) {
@@ -517,7 +527,7 @@ export function h3IsPentagon(h3Index) {
  * the icosahedron and subject to shape distortion adding extra points on
  * icosahedron edges, making them not true hexagons).
  * @static
- * @param  {H3Index} h3Index  H3 index to check
+ * @param  {H3IndexInput} h3Index  H3 index to check
  * @return {boolean}          isResClassIII
  */
 export function h3IsResClassIII(h3Index) {
@@ -528,7 +538,7 @@ export function h3IsResClassIII(h3Index) {
 /**
  * Get the number of the base cell for a given H3 index
  * @static
- * @param  {H3Index} h3Index  H3 index to get the base cell for
+ * @param  {H3IndexInput} h3Index  H3 index to get the base cell for
  * @return {number}           Index of the base cell (0-121)
  */
 export function h3GetBaseCell(h3Index) {
@@ -539,7 +549,7 @@ export function h3GetBaseCell(h3Index) {
 /**
  * Get the indices of all icosahedron faces intersected by a given H3 index
  * @static
- * @param  {H3Index} h3Index  H3 index to get faces for
+ * @param  {H3IndexInput} h3Index  H3 index to get faces for
  * @return {number[]}         Indices (0-19) of all intersected faces
  */
 export function h3GetFaces(h3Index) {
@@ -555,7 +565,7 @@ export function h3GetFaces(h3Index) {
 /**
  * Returns the resolution of an H3 index
  * @static
- * @param  {H3Index} h3Index H3 index to get resolution
+ * @param  {H3IndexInput} h3Index H3 index to get resolution
  * @return {number}          The number (0-15) resolution, or -1 if invalid
  */
 export function h3GetResolution(h3Index) {
@@ -586,7 +596,7 @@ export function geoToH3(lat, lng, res) {
 /**
  * Get the lat,lon center of a given hexagon
  * @static
- * @param  {H3Index} h3Index  H3 index
+ * @param  {H3IndexInput} h3Index  H3 index
  * @return {number[]}         Point as a [lat, lng] pair
  */
 export function h3ToGeo(h3Index) {
@@ -622,7 +632,7 @@ export function h3ToGeoBoundary(h3Index, formatAsGeoJson) {
 /**
  * Get the parent of the given hexagon at a particular resolution
  * @static
- * @param  {H3Index} h3Index  H3 index to get parent for
+ * @param  {H3IndexInput} h3Index  H3 index to get parent for
  * @param  {number} res       Resolution of hexagon to return
  * @return {H3Index}          H3 index of parent, or null for invalid input
  */
@@ -634,7 +644,7 @@ export function h3ToParent(h3Index, res) {
 /**
  * Get the children/descendents of the given hexagon at a particular resolution
  * @static
- * @param  {H3Index} h3Index  H3 index to get children for
+ * @param  {H3IndexInput} h3Index  H3 index to get children for
  * @param  {number} res       Resolution of hexagons to return
  * @return {H3Index[]}        H3 indexes of children, or empty array for invalid input
  */
@@ -656,7 +666,7 @@ export function h3ToChildren(h3Index, res) {
 /**
  * Get the center child of the given hexagon at a particular resolution
  * @static
- * @param  {H3Index} h3Index  H3 index to get center child for
+ * @param  {H3IndexInput} h3Index  H3 index to get center child for
  * @param  {number} res       Resolution of hexagon to return
  * @return {H3Index}          H3 index of child, or null for invalid input
  */
@@ -668,7 +678,7 @@ export function h3ToCenterChild(h3Index, res) {
 /**
  * Get all hexagons in a k-ring around a given center. The order of the hexagons is undefined.
  * @static
- * @param  {H3Index} h3Index  H3 index of center hexagon
+ * @param  {H3IndexInput} h3Index  H3 index of center hexagon
  * @param  {number} ringSize  Radius of k-ring
  * @return {H3Index[]}        H3 indexes for all hexagons in ring
  */
@@ -686,7 +696,7 @@ export function kRing(h3Index, ringSize) {
  * Get all hexagons in a k-ring around a given center, in an array of arrays
  * ordered by distance from the origin. The order of the hexagons within each ring is undefined.
  * @static
- * @param  {H3Index} h3Index  H3 index of center hexagon
+ * @param  {H3IndexInput} h3Index  H3 index of center hexagon
  * @param  {number} ringSize  Radius of k-ring
  * @return {H3Index[][]}      Array of arrays with H3 indexes for all hexagons each ring
  */
@@ -719,7 +729,7 @@ export function kRingDistances(h3Index, ringSize) {
  * Get all hexagons in a hollow hexagonal ring centered at origin with sides of a given length.
  * Unlike kRing, this function will throw an error if there is a pentagon anywhere in the ring.
  * @static
- * @param  {H3Index} h3Index  H3 index of center hexagon
+ * @param  {H3IndexInput} h3Index  H3 index of center hexagon
  * @param  {number} ringSize  Radius of ring
  * @return {H3Index[]}        H3 indexes for all hexagons in ring
  * @throws {Error}            If the algorithm could not calculate the ring
@@ -778,7 +788,7 @@ export function polyfill(coordinates, res, isGeoJson) {
  * coordinates). Coordinates are returned as [lat, lng] pairs unless GeoJSON
  * is requested.
  * @static
- * @param {H3Index[]} h3Indexes       H3 indexes to get outlines for
+ * @param {H3IndexInput[]} h3Indexes       H3 indexes to get outlines for
  * @param {boolean} [formatAsGeoJson] Whether to provide GeoJSON output:
  *                                    [lng, lat], closed loops
  * @return {number[][][][]}           MultiPolygon-style output.
@@ -810,7 +820,7 @@ export function h3SetToMultiPolygon(h3Indexes, formatAsGeoJson) {
  * Compact a set of hexagons of the same resolution into a set of hexagons across
  * multiple levels that represents the same area.
  * @static
- * @param  {H3Index[]} h3Set H3 indexes to compact
+ * @param  {H3IndexInput[]} h3Set H3 indexes to compact
  * @return {H3Index[]}       Compacted H3 indexes
  * @throws {Error}           If the input is invalid (e.g. duplicate hexagons)
  */
@@ -839,7 +849,7 @@ export function compact(h3Set) {
 /**
  * Uncompact a compacted set of hexagons to hexagons of the same resolution
  * @static
- * @param  {H3Index[]} compactedSet H3 indexes to uncompact
+ * @param  {H3IndexInput[]} compactedSet H3 indexes to uncompact
  * @param  {number}    res          The resolution to uncompact to
  * @return {H3Index[]}              The uncompacted H3 indexes
  * @throws {Error}                  If the input is invalid (e.g. invalid resolution)
@@ -875,8 +885,8 @@ export function uncompact(compactedSet, res) {
 /**
  * Whether two H3 indexes are neighbors (share an edge)
  * @static
- * @param  {H3Index} origin      Origin hexagon index
- * @param  {H3Index} destination Destination hexagon index
+ * @param  {H3IndexInput} origin      Origin hexagon index
+ * @param  {H3IndexInput} destination Destination hexagon index
  * @return {boolean}             Whether the hexagons share an edge
  */
 export function h3IndexesAreNeighbors(origin, destination) {
@@ -888,8 +898,8 @@ export function h3IndexesAreNeighbors(origin, destination) {
 /**
  * Get an H3 index representing a unidirectional edge for a given origin and destination
  * @static
- * @param  {H3Index} origin      Origin hexagon index
- * @param  {H3Index} destination Destination hexagon index
+ * @param  {H3IndexInput} origin      Origin hexagon index
+ * @param  {H3IndexInput} destination Destination hexagon index
  * @return {H3Index}             H3 index of the edge, or null if no edge is shared
  */
 export function getH3UnidirectionalEdge(origin, destination) {
@@ -901,7 +911,7 @@ export function getH3UnidirectionalEdge(origin, destination) {
 /**
  * Get the origin hexagon from an H3 index representing a unidirectional edge
  * @static
- * @param  {H3Index} edgeIndex H3 index of the edge
+ * @param  {H3IndexInput} edgeIndex H3 index of the edge
  * @return {H3Index}           H3 index of the edge origin
  */
 export function getOriginH3IndexFromUnidirectionalEdge(edgeIndex) {
@@ -912,7 +922,7 @@ export function getOriginH3IndexFromUnidirectionalEdge(edgeIndex) {
 /**
  * Get the destination hexagon from an H3 index representing a unidirectional edge
  * @static
- * @param  {H3Index} edgeIndex H3 index of the edge
+ * @param  {H3IndexInput} edgeIndex H3 index of the edge
  * @return {H3Index}           H3 index of the edge destination
  */
 export function getDestinationH3IndexFromUnidirectionalEdge(edgeIndex) {
@@ -923,7 +933,7 @@ export function getDestinationH3IndexFromUnidirectionalEdge(edgeIndex) {
 /**
  * Whether the input is a valid unidirectional edge
  * @static
- * @param  {H3Index} edgeIndex H3 index of the edge
+ * @param  {H3IndexInput} edgeIndex H3 index of the edge
  * @return {boolean}           Whether the index is valid
  */
 export function h3UnidirectionalEdgeIsValid(edgeIndex) {
@@ -934,7 +944,7 @@ export function h3UnidirectionalEdgeIsValid(edgeIndex) {
 /**
  * Get the [origin, destination] pair represented by a unidirectional edge
  * @static
- * @param  {H3Index} edgeIndex H3 index of the edge
+ * @param  {H3IndexInput} edgeIndex H3 index of the edge
  * @return {H3Index[]}         [origin, destination] pair as H3 indexes
  */
 export function getH3IndexesFromUnidirectionalEdge(edgeIndex) {
@@ -951,7 +961,7 @@ export function getH3IndexesFromUnidirectionalEdge(edgeIndex) {
  * Get all of the unidirectional edges with the given H3 index as the origin (i.e. an edge to
  * every neighbor)
  * @static
- * @param  {H3Index} h3Index   H3 index of the origin hexagon
+ * @param  {H3IndexInput} h3Index   H3 index of the origin hexagon
  * @return {H3Index[]}         List of unidirectional edges
  */
 export function getH3UnidirectionalEdgesFromHexagon(h3Index) {
@@ -968,7 +978,7 @@ export function getH3UnidirectionalEdgesFromHexagon(h3Index) {
  * Get the vertices of a given edge as an array of [lat, lng] points. Note that for edges that
  * cross the edge of an icosahedron face, this may return 3 coordinates.
  * @static
- * @param  {H3Index} edgeIndex        H3 index of the edge
+ * @param  {H3IndexInput} edgeIndex        H3 index of the edge
  * @param {boolean} [formatAsGeoJson] Whether to provide GeoJSON output: [lng, lat]
  * @return {number[][]}               Array of geo coordinate pairs
  */
@@ -986,8 +996,8 @@ export function getH3UnidirectionalEdgeBoundary(edgeIndex, formatAsGeoJson) {
  * to find the distance between two indexes if they are very far apart or
  * on opposite sides of a pentagon.
  * @static
- * @param  {H3Index} origin      Origin hexagon index
- * @param  {H3Index} destination Destination hexagon index
+ * @param  {H3IndexInput} origin      Origin hexagon index
+ * @param  {H3IndexInput} destination Destination hexagon index
  * @return {number}              Distance between hexagons, or a negative
  *                               number if the distance could not be computed
  */
@@ -1014,8 +1024,8 @@ export function h3Distance(origin, destination) {
  *    Cartesian lines or great arcs.
  *
  * @static
- * @param  {H3Index} origin      Origin hexagon index
- * @param  {H3Index} destination Destination hexagon index
+ * @param  {H3IndexInput} origin      Origin hexagon index
+ * @param  {H3IndexInput} destination Destination hexagon index
  * @return {H3Index[]}           H3 indexes connecting origin and destination
  * @throws {Error}               If the line cannot be calculated
  */
@@ -1047,8 +1057,8 @@ export function h3Line(origin, destination) {
  * - This function is experimental, and its output is not guaranteed
  * to be compatible across different versions of H3.
  * @static
- * @param  {H3Index} origin      Origin H3 index
- * @param  {H3Index} destination H3 index for which to find relative coordinates
+ * @param  {H3IndexInput} origin      Origin H3 index
+ * @param  {H3IndexInput} destination H3 index for which to find relative coordinates
  * @return {CoordIJ}             Coordinates as an `{i, j}` pair
  * @throws {Error}               If the IJ coordinates cannot be calculated
  */
@@ -1093,7 +1103,7 @@ export function experimentalH3ToLocalIj(origin, destination) {
  * - This function is experimental, and its output is not guaranteed
  * to be compatible across different versions of H3.
  * @static
- * @param  {H3Index} origin     Origin H3 index
+ * @param  {H3IndexInput} origin     Origin H3 index
  * @param  {CoordIJ} coords     Coordinates as an `{i, j}` pair
  * @return {H3Index}            H3 index at the relative coordinates
  * @throws {Error}              If the H3 index cannot be calculated

--- a/lib/h3core.js
+++ b/lib/h3core.js
@@ -118,7 +118,12 @@ const INVALID_HEXIDECIMAL_CHAR = /[^0-9a-fA-F]/;
  * @return {number[]}         A two-element array with 32 lower bits and 32 upper bits
  */
 function h3IndexToSplitLong(h3Index) {
-    if (Array.isArray(h3Index) && Number.isInteger(h3Index[0]) && Number.isInteger(h3Index[1])) {
+    if (
+        Array.isArray(h3Index) &&
+        h3Index.length === 2 &&
+        Number.isInteger(h3Index[0]) &&
+        Number.isInteger(h3Index[1])
+    ) {
         return h3Index;
     }
     if (typeof h3Index !== 'string' || INVALID_HEXIDECIMAL_CHAR.test(h3Index)) {

--- a/lib/h3core.js
+++ b/lib/h3core.js
@@ -58,7 +58,7 @@ const SZ_COORDIJ = H3.sizeOfCoordIJ();
  * 64-bit hexidecimal string representation of an H3 index,
  * or two 32-bit integers in little endian order in an array.
  * @static
- * @typedef {H3Index | number[]} H3IndexInput
+ * @typedef {string | number[]} H3IndexInput
  */
 
 /**

--- a/test/h3core.spec.js
+++ b/test/h3core.spec.js
@@ -105,6 +105,15 @@ test('h3IsValid', assert => {
     assert.end();
 });
 
+test('h3IsValid', assert => {
+    assert.ok(h3.h3IsValid([0x3fffffff, 0x8528347]), 'Integer H3 index is considered an index');
+    assert.ok(!h3.h3IsValid([0x73fffffff, 0xff2834]), 'Integer with incorrect bits is not considered an index');
+    assert.ok(!h3.h3IsValid([]), 'Empty array is not valid');
+    assert.ok(!h3.h3IsValid([1]), 'Array with a single element is not valid');
+    assert.ok(!h3.h3IsValid([0x3fffffff, 0x8528347, 0]), 'Array with an additional element is not valid');
+    assert.end();
+});
+
 test('geoToH3', assert => {
     const h3Index = h3.geoToH3(37.3615593, -122.0553238, 5);
     assert.equal(h3Index, '85283473fffffff', 'Got the expected H3 index back');
@@ -132,6 +141,16 @@ test('h3GetResolution', assert => {
 
 test('h3ToGeo', assert => {
     const latlng = h3.h3ToGeo('85283473fffffff');
+    assert.deepEqual(
+        toLowPrecision(latlng),
+        toLowPrecision([37.34579337536848, -121.97637597255124]),
+        'lat/lng matches expected'
+    );
+    assert.end();
+});
+
+test('h3ToGeo - Integer', assert => {
+    const latlng = h3.h3ToGeo([0x3fffffff, 0x8528347]);
     assert.deepEqual(
         toLowPrecision(latlng),
         toLowPrecision([37.34579337536848, -121.97637597255124]),
@@ -855,6 +874,12 @@ test('uncompact - Invalid', assert => {
         /Failed to uncompact/,
         'got expected error for invalid compacted resolution input'
     );
+
+    assert.end();
+});
+
+test('uncompact - Integer', assert => {
+    assert.deepEqual(h3.uncompact([[0x3fffffff, 0x8528347]], 5), ['85283473fffffff'], 'got a single index for same res input');
 
     assert.end();
 });

--- a/test/h3core.spec.js
+++ b/test/h3core.spec.js
@@ -107,10 +107,16 @@ test('h3IsValid', assert => {
 
 test('h3IsValid', assert => {
     assert.ok(h3.h3IsValid([0x3fffffff, 0x8528347]), 'Integer H3 index is considered an index');
-    assert.ok(!h3.h3IsValid([0x73fffffff, 0xff2834]), 'Integer with incorrect bits is not considered an index');
+    assert.ok(
+        !h3.h3IsValid([0x73fffffff, 0xff2834]),
+        'Integer with incorrect bits is not considered an index'
+    );
     assert.ok(!h3.h3IsValid([]), 'Empty array is not valid');
     assert.ok(!h3.h3IsValid([1]), 'Array with a single element is not valid');
-    assert.ok(!h3.h3IsValid([0x3fffffff, 0x8528347, 0]), 'Array with an additional element is not valid');
+    assert.ok(
+        !h3.h3IsValid([0x3fffffff, 0x8528347, 0]),
+        'Array with an additional element is not valid'
+    );
     assert.end();
 });
 
@@ -879,7 +885,11 @@ test('uncompact - Invalid', assert => {
 });
 
 test('uncompact - Integer', assert => {
-    assert.deepEqual(h3.uncompact([[0x3fffffff, 0x8528347]], 5), ['85283473fffffff'], 'got a single index for same res input');
+    assert.deepEqual(
+        h3.uncompact([[0x3fffffff, 0x8528347]], 5),
+        ['85283473fffffff'],
+        'got a single index for same res input'
+    );
 
     assert.end();
 });


### PR DESCRIPTION
This PR adds the ability to give h3-js a little endian pair of 32 bit integers. This can be useful for performance, where 32-bit integers are the output of other libs or data structures.