### PR TITLE
Fix jsdoc comment for UNITS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file. This library adheres to a versioning policy described in [the README](./README.md#versioning). The public API of this library consists of the functions exported in [h3core.js](./lib/h3core.js).
 
 ## [Unreleased]
-- *None*
+- Fix jsdoc comment for `UNITS` ([#94](https://github.com/uber/h3-js/pull/94))
 
 ## [3.6.4] - 2020-06-02
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ const coordinates = h3.h3SetToMultiPolygon(hexagons, true);
     * [.radsToDegs(rad)](#module_h3.radsToDegs) ⇒ <code>number</code>
     * [.H3Index](#module_h3.H3Index) : <code>string</code>
     * [.CoordIJ](#module_h3.CoordIJ) : <code>Object</code>
+    * [.UNITS](#module_h3.UNITS) : <code>Object</code>
 
 
 * * *
@@ -785,6 +786,23 @@ Coordinates as an `{i, j}` pair
 | --- | --- |
 | i | <code>number</code> | 
 | j | <code>number</code> | 
+
+
+* * *
+
+<a name="module_h3.UNITS"></a>
+
+### h3.UNITS : <code>Object</code>
+Length/Area units
+
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| m | <code>string</code> | 
+| km | <code>string</code> | 
+| m2 | <code>string</code> | 
+| km2 | <code>string</code> | 
 
 
 * * *

--- a/lib/h3core.js
+++ b/lib/h3core.js
@@ -65,6 +65,17 @@ const SZ_COORDIJ = H3.sizeOfCoordIJ();
 
 // ----------------------------------------------------------------------------
 // Unit constants
+
+/**
+ * Length/Area units
+ * @static
+ * @typedef UNITS
+ * @type {Object}
+ * @property {string} m
+ * @property {string} km
+ * @property {string} m2
+ * @property {string} km2
+ */
 export const UNITS = {
     m: 'm',
     km: 'km',


### PR DESCRIPTION
Currently, the UNITS constant is not exported in the TypeScript declaration file since it is not annotated with the appropriate jsdoc comment. This Pull Request adds the jsdoc comment to fix the problem.

```
import {UNITS} from 'h3-js' // Error: Module '"h3-js"' has no exported member 'UNITS'.ts (2305)
```