### PR TITLE
Move most CI jobs to Node 12 only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,17 @@
 language: node_js
 
+# These Node versions get only lightweight tests to ensure compatibility
 node_js:
   - '6'
   - '8'
   - '10'
-  - '12'
+  - '14'
 
 # The following setup applies to all Node versions
 
 before_install:
   - mkdir -p "$HOME/.yarn/bin"
-  - curl -L -o "$HOME/.yarn/bin/yarn" https://github.com/yarnpkg/yarn/releases/download/v1.17.3/yarn-1.17.3.js
+  - curl -L -o "$HOME/.yarn/bin/yarn" https://github.com/yarnpkg/yarn/releases/download/v1.22.10/yarn-1.22.10.js
   - chmod +x "$HOME/.yarn/bin/yarn"
   - export PATH="$HOME/.yarn/bin:$PATH"
 
@@ -22,9 +23,9 @@ script:
 
 matrix:
   include:
-  # Only run the full CI suite for Node 12. Tests are expected to
-  # pass for all Node versions, but the build only needs to work
-  # for the development version (currently 12 per Volta config)
+  # Run the full CI suite for Node 12. Tests are expected to pass for all Node versions,
+  # but the build only needs to work for the development version, which should match the
+  # Volta config in package.json
   - node_js: '12'
 
     sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,51 @@
 language: node_js
 
 node_js:
+  - '6'
   - '8'
   - '10'
   - '12'
 
-sudo: required
-
-services:
-  - docker
+# The following setup applies to all Node versions
 
 before_install:
   - mkdir -p "$HOME/.yarn/bin"
   - curl -L -o "$HOME/.yarn/bin/yarn" https://github.com/yarnpkg/yarn/releases/download/v1.17.3/yarn-1.17.3.js
   - chmod +x "$HOME/.yarn/bin/yarn"
   - export PATH="$HOME/.yarn/bin:$PATH"
-  - yarn docker-boot
 
 install:
   - yarn --ignore-engines
 
-before_script:
-  - yarn build-emscripten
-
 script:
-  - yarn lint
   - yarn test-fast
-  - yarn check-prettier
-  - yarn check-docs
-  - yarn check-tsd
-  - yarn cover
 
-after_success:
-  - npm install -g coveralls
-  - nyc report --reporter=text-lcov | coveralls
+matrix:
+  include:
+  # Only run the full CI suite for Node 12. Tests are expected to
+  # pass for all Node versions, but the build only needs to work
+  # for the development version (currently 12 per Volta config)
+  - node_js: '12'
+
+    sudo: required
+  
+    services:
+      - docker
+  
+    before_install:
+      - yarn docker-boot
+  
+    before_script:
+      - yarn build-emscripten
+  
+    script:
+      - yarn lint
+      - yarn test-fast
+      - yarn check-prettier
+      - yarn check-docs
+      - yarn check-tsd
+      - yarn cover
+  
+    after_success:
+      - npm install -g coveralls
+      - nyc report --reporter=text-lcov | coveralls

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "typescript": "^3.6.3"
   },
   "resolutions": {
-    "lodash": "4.17.15",
     "js-yaml": "3.13.1",
     "ws": "3.3.3"
   },

--- a/test/h3core.spec.js
+++ b/test/h3core.spec.js
@@ -29,8 +29,8 @@ function toLowPrecision(maybeNumber) {
     throw new Error(`Unhandled type: ${maybeNumber}`);
 }
 
-function almostEqual(a, b, epsilon = Number.EPSILON * 10) {
-    return Math.abs(a - b) < epsilon;
+function almostEqual(a, b, factor = 1e-6) {
+    return Math.abs(a - b) < a * factor;
 }
 
 // Assert a vertex loop regardless of starting vertex
@@ -1511,7 +1511,7 @@ test('cellArea', assert => {
             // res 0 has high distortion of average area due to high pentagon proportion
             res === 0 ||
                 // This seems to be the lowest factor that works for other resolutions
-                almostEqual(cellAreaKm2, h3.hexArea(res, h3.UNITS.km2), cellAreaKm2 * 0.4),
+                almostEqual(cellAreaKm2, h3.hexArea(res, h3.UNITS.km2), 0.4),
             `Area is close to average area at res ${res}, km2`
         );
         const cellAreaM2 = h3.cellArea(h3Index, h3.UNITS.m2);
@@ -1519,7 +1519,7 @@ test('cellArea', assert => {
             // res 0 has high distortion of average area due to high pentagon proportion
             res === 0 ||
                 // This seems to be the lowest factor that works for other resolutions
-                almostEqual(cellAreaM2, h3.hexArea(res, h3.UNITS.m2), cellAreaM2 * 0.4),
+                almostEqual(cellAreaM2, h3.hexArea(res, h3.UNITS.m2), 0.4),
             `Area is close to average area at res ${res}, m2`
         );
         assert.ok(cellAreaM2 > cellAreaKm2, 'm2 > Km2');
@@ -1550,7 +1550,7 @@ test('exactEdgeLength', assert => {
                 // res 0 has high distortion of average edge length due to high pentagon proportion
                 res === 0 ||
                     // This seems to be the lowest factor that works for other resolutions
-                    almostEqual(lengthKm, h3.edgeLength(res, h3.UNITS.km), lengthKm * 0.2),
+                    almostEqual(lengthKm, h3.edgeLength(res, h3.UNITS.km), 0.2),
                 `Edge length is close to average edge length at res ${res}, km`
             );
             const lengthM = h3.exactEdgeLength(edge, h3.UNITS.m);
@@ -1558,7 +1558,7 @@ test('exactEdgeLength', assert => {
                 // res 0 has high distortion of average edge length due to high pentagon proportion
                 res === 0 ||
                     // This seems to be the lowest factor that works for other resolutions
-                    almostEqual(lengthM, h3.edgeLength(res, h3.UNITS.m), lengthM * 0.2),
+                    almostEqual(lengthM, h3.edgeLength(res, h3.UNITS.m), 0.2),
                 `Edge length is close to average edge length at res ${res}, m`
             );
             assert.ok(lengthM > lengthKm, 'm > Km');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3791,10 +3791,10 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.15, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.4, lodash@^4.3.0:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+lodash@4.17.19, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.4, lodash@^4.3.0:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 lru-cache@^4.0.1:
   version "4.1.5"
@@ -7060,17 +7060,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@>=2.8.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
-  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
-
-typescript@^3.2.1:
-  version "3.9.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
-  integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
-
-typescript@^3.6.3:
+typescript@>=2.8.3, typescript@^3.2.1, typescript@^3.6.3:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7065,10 +7065,15 @@ typescript@>=2.8.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
-typescript@^3.2.1, typescript@^3.6.3:
+typescript@^3.2.1:
   version "3.9.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
   integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
+
+typescript@^3.6.3:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 typical@^2.4.2, typical@^2.6.0, typical@^2.6.1:
   version "2.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3791,7 +3791,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.19, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.4, lodash@^4.3.0:
+lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==


### PR DESCRIPTION
Cleans up the Travis config:
- Splits up the Node versions into "compatibility" versions, which just run the tests, and a "development" version, which runs the full suite, including lint, Emscripten build, doc generation, etc.
- Sets the development version to Node 12 and adds compatibility tests for Node 6 and Node 14. 

This should make Travis slightly faster and ensures that we can keep updating dev dependencies without dropping compatibility tests for old Node versions.