### PR TITLE
Fix bug in freeing geo polygon memory

### DIFF
--- a/lib/h3core.js
+++ b/lib/h3core.js
@@ -251,9 +251,12 @@ function destroyGeoPolygon(geoPolygon) {
     C._free(C.getValue(geoPolygon + geofenceOffset + geofenceArrayOffset, 'i8*'));
     // Free the vertex array for the holes, if any
     const numHoles = C.getValue(geoPolygon + numHolesOffset, 'i32');
-    const holes = C.getValue(geoPolygon + holesOffset, 'i32');
-    for (let i = 0; i < numHoles; i++) {
-        C._free(C.getValue(holes + SZ_GEOFENCE * i + geofenceArrayOffset, 'i8*'));
+    if (numHoles > 0) {
+        const holes = C.getValue(geoPolygon + holesOffset, 'i32');
+        for (let i = 0; i < numHoles; i++) {
+            C._free(C.getValue(holes + SZ_GEOFENCE * i + geofenceArrayOffset, 'i8*'));
+        }
+        C._free(holes);
     }
     C._free(geoPolygon);
 }

--- a/lib/h3core.js
+++ b/lib/h3core.js
@@ -245,12 +245,15 @@ function destroyGeoPolygon(geoPolygon) {
     const geofenceOffset = 0;
     const numHolesOffset = geofenceOffset + SZ_GEOFENCE;
     const holesOffset = numHolesOffset + SZ_INT;
-    // Free the outer loop
-    C._free(C.getValue(geoPolygon + geofenceOffset, 'i8*'));
-    // Free the holes, if any
+    // Offset of the geofence vertex array pointer within the Geofence struct
+    const geofenceArrayOffset = SZ_INT;
+    // Free the outer vertex array
+    C._free(C.getValue(geoPolygon + geofenceOffset + geofenceArrayOffset, 'i8*'));
+    // Free the vertex array for the holes, if any
     const numHoles = C.getValue(geoPolygon + numHolesOffset, 'i32');
+    const holes = C.getValue(geoPolygon + holesOffset, 'i32');
     for (let i = 0; i < numHoles; i++) {
-        C._free(C.getValue(geoPolygon + holesOffset + SZ_GEOFENCE * i, 'i8*'));
+        C._free(C.getValue(holes + SZ_GEOFENCE * i + geofenceArrayOffset, 'i8*'));
     }
     C._free(geoPolygon);
 }

--- a/test/h3core.spec.js
+++ b/test/h3core.spec.js
@@ -689,8 +689,6 @@ test('polyfill - memory management bug (#103)', assert => {
 });
 
 test('polyfill - memory management bug (#103, holes)', assert => {
-    // Note that when this memory mangement issue occurs, it makes a number of *other* tests fail.
-    // Unfortunately this test itself doesn't seem to fail, though the
     const simplePolygon = makePolygon(4);
     const complexPolygon = [simplePolygon, makePolygon(1260, 0.5), makePolygon(2000, 0.5)];
 

--- a/test/h3core.spec.js
+++ b/test/h3core.spec.js
@@ -676,7 +676,8 @@ function makePolygon(numVerts, radius = 1) {
 
 test('polyfill - memory management bug (#103)', assert => {
     // Note that when this memory mangement issue occurs, it makes a number of *other* tests fail.
-    // Unfortunately this test itself doesn't seem to fail, though the
+    // Unfortunately this test itself doesn't seem to fail, though the original pair of polygons
+    // in #103 failed deterministically with this length check.
     const simplePolygon = makePolygon(4);
     const complexPolygon = makePolygon(1260);
 

--- a/test/h3core.spec.js
+++ b/test/h3core.spec.js
@@ -663,6 +663,45 @@ test('polyfill - BBox corners (#67)', assert => {
     assert.end();
 });
 
+// Helper - make a polygon from a unit circle with an arbitrary number of vertices
+function makePolygon(numVerts, radius = 1) {
+    const interval = (2 * Math.PI) / numVerts;
+    const polygon = [];
+    for (let i = 0; i < numVerts; i++) {
+        const theta = interval * i;
+        polygon.push([radius * Math.cos(theta), radius * Math.sin(theta)]);
+    }
+    return polygon;
+}
+
+test('polyfill - memory management bug (#103)', assert => {
+    // Note that when this memory mangement issue occurs, it makes a number of *other* tests fail.
+    // Unfortunately this test itself doesn't seem to fail, though the
+    const simplePolygon = makePolygon(4);
+    const complexPolygon = makePolygon(1260);
+
+    const len1 = h3.polyfill(simplePolygon, 3).length;
+    h3.polyfill(complexPolygon, 3);
+    const len2 = h3.polyfill(simplePolygon, 3).length;
+
+    assert.equal(len1, len2, 'polyfill with many vertexes should not mess up later polyfills');
+    assert.end();
+});
+
+test('polyfill - memory management bug (#103, holes)', assert => {
+    // Note that when this memory mangement issue occurs, it makes a number of *other* tests fail.
+    // Unfortunately this test itself doesn't seem to fail, though the
+    const simplePolygon = makePolygon(4);
+    const complexPolygon = [simplePolygon, makePolygon(1260, 0.5), makePolygon(2000, 0.5)];
+
+    const len1 = h3.polyfill(simplePolygon, 3).length;
+    h3.polyfill(complexPolygon, 3);
+    const len2 = h3.polyfill(simplePolygon, 3).length;
+
+    assert.equal(len1, len2, 'polyfill with many vertexes should not mess up later polyfills');
+    assert.end();
+});
+
 test('h3SetToMultiPolygon - Empty', assert => {
     const h3Indexes = [];
     const multiPolygon = h3.h3SetToMultiPolygon(h3Indexes);


### PR DESCRIPTION
Closes #103 

This fixes some errors in freeing `GeoPolygon` memory, which could get the Emscripten virtual memory management into a bad state. 

Explanation of the issue: We were expecting the `GeoPolygon` reference to `Geofence` to be a pointer, but it’s not, the struct is inlined into `GeoPolygon`. So I was trying to free the value at the geofence position, because I thought it was a pointer, but I’m actually getting the first value in the Geofence struct, which is `numVerts`, and trying to free that. C would probably segfault at this point, Emscripten just gets confused and ends up with undefined behavior in future calls.