### PR TITLE
Update README and CHANGELOG for v4 transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 All notable changes to this project will be documented in this file. This library adheres to a versioning policy described in [the README](./README.md#versioning). The public API of this library consists of the functions exported in [h3core.js](./lib/h3core.js).
 
 ## [Unreleased]
-- *None*
+### Breaking Changes
+- Updated the core library to `v4.0.0-rc2`. This update renames the majority of the H3 functions. You can see a [list of changed function names](https://h3geo.org/docs/next/library/migration-3.x/functions) in the core library documentation. For the most part, upgrading to v4 for Javascript consumers should be a straightforward search & replace between the old names and the new.
+- Added more cases in which JS errors may be thrown. In H3 v3, many functions would fail silently with invalid input, returning `null` or similar signal values. In H3 v4, we will throw descriptive errors for most instances of bad input.
 
 ## [3.7.2] - 2021-04-29
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/uber/h3-js/badge.svg?branch=master)](https://coveralls.io/github/uber/h3-js?branch=master)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![npm version](https://badge.fury.io/js/h3-js.svg)](https://badge.fury.io/js/h3-js)
-[![H3 Version](https://img.shields.io/badge/h3_api-v3.7.1-blue.svg)](https://github.com/uber/h3/releases/tag/v3.7.1)
+[![H3 Version](https://img.shields.io/badge/h3_api-v4.0.0-rc2-blue.svg)](https://github.com/uber/h3/releases/tag/v4.0.0-rc2)
 
 The `h3-js` library provides a pure-JavaScript version of the [H3 Core Library](https://github.com/uber/h3), a hexagon-based geographic grid system. It can be used either in Node >= 6 or in the browser. The core library is transpiled from C using [emscripten](http://kripken.github.io/emscripten-site), offering full parity with the C API and highly efficient operations.
 
@@ -22,6 +22,11 @@ For more information on H3 and for the full API documentation, please see the [H
     npm install h3-js
 
 ## Usage
+
+> :construction: **Note:** The following usage docs apply to **H3 v4**, which is currently still in the Release Candidate stage. 
+> 
+> - For v3 docs, [see the latest v3.x.x release](https://github.com/uber/h3-js/blob/v3.7.2/README.md).
+> - For breaking changes in v4, [see the CHANGELOG](./CHANGELOG.md). In particular, most [function names have changed](https://h3geo.org/docs/next/library/migration-3.x/functions).
 
 The library uses ES6 modules. Bundles for Node and the browser are built to the `dist` folder.
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ For more information on H3 and for the full API documentation, please see the [H
 
 ## Usage
 
-> :construction: **Note:** The following usage docs apply to **H3 v4**, which is currently still in the Release Candidate stage. 
-> 
+> :construction: **Note:** The following usage docs apply to **H3 v4**, which is currently still in the Release Candidate stage.
+>
 > - For v3 docs, [see the latest v3.x.x release](https://github.com/uber/h3-js/blob/v3.7.2/README.md).
 > - For breaking changes in v4, [see the CHANGELOG](./CHANGELOG.md). In particular, most [function names have changed](https://h3geo.org/docs/next/library/migration-3.x/functions).
 

--- a/doc-files/README.tmpl.md
+++ b/doc-files/README.tmpl.md
@@ -8,7 +8,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/uber/h3-js/badge.svg?branch=master)](https://coveralls.io/github/uber/h3-js?branch=master)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![npm version](https://badge.fury.io/js/h3-js.svg)](https://badge.fury.io/js/h3-js)
-[![H3 Version](https://img.shields.io/badge/h3_api-v3.7.1-blue.svg)](https://github.com/uber/h3/releases/tag/v3.7.1)
+[![H3 Version](https://img.shields.io/badge/h3_api-v4.0.0-rc2-blue.svg)](https://github.com/uber/h3/releases/tag/v4.0.0-rc2)
 
 The `h3-js` library provides a pure-JavaScript version of the [H3 Core Library](https://github.com/uber/h3), a hexagon-based geographic grid system. It can be used either in Node >= 6 or in the browser. The core library is transpiled from C using [emscripten](http://kripken.github.io/emscripten-site), offering full parity with the C API and highly efficient operations.
 
@@ -22,6 +22,11 @@ For more information on H3 and for the full API documentation, please see the [H
     npm install h3-js
 
 ## Usage
+
+> :construction: **Note:** The following usage docs apply to **H3 v4**, which is currently still in the Release Candidate stage.
+>
+> - For v3 docs, [see the latest v3.x.x release](https://github.com/uber/h3-js/blob/v3.7.2/README.md).
+> - For breaking changes in v4, [see the CHANGELOG](./CHANGELOG.md). In particular, most [function names have changed](https://h3geo.org/docs/next/library/migration-3.x/functions).
 
 The library uses ES6 modules. Bundles for Node and the browser are built to the `dist` folder.
 


### PR DESCRIPTION
Adds a missing CHANGELOG entry for the v4.0.0-rc2 update, and adds a warning in the README about the coming transition and the mismatch between the published package and the README docs.