### PR TITLE
Prepare for Release v4.0.0-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file. This library adheres to a versioning policy described in [the README](./README.md#versioning). The public API of this library consists of the functions exported in [h3core.js](./lib/h3core.js).
 
 ## [Unreleased]
+
+## [4.0.0-rc1] - 2022-07-28
 ### Added
 - Added vertex mode functions (#138)
 ### Breaking Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "h3-js",
-  "version": "3.7.2",
+  "version": "4.0.0-rc1",
   "description": "Pure-Javascript version of the H3 library, a hexagon-based geographic grid system",
   "author": "Nick Rabinowitz <nickr@uber.com>",
   "contributors": [


### PR DESCRIPTION
- Updates version
- Updates CHANGELOG

Following Java, I went with `rc1` instead of `rc4` so that the JS bindings would have their own release candidate numbering.