### PR TITLE
Fix: Fail pre-publish script if there are uncommitted changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 All notable changes to this project will be documented in this file. This library adheres to a versioning policy described in [the README](./README.md#versioning). The public API of this library consists of the functions exported in [h3core.js](./lib/h3core.js).
 
 ## [Unreleased]
+### Fixed
+- Fail package publish if there are library changes
 
-## [4.0.0-rc2] - 2022-08-10
+## [4.0.0-rc2] - 2022-08-11
 ### Added
 - Added legacy API wrapper with Typescript types (#146)
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "cover-view": "yarn rollup-test && nyc --clean --reporter=html node dist/test.js && open coverage/index.html",
     "benchmark-node": "yarn rollup-benchmark-node && node dist/benchmark.node.js",
     "benchmark-browser": "yarn rollup-benchmark-browser && budo dist/benchmark.browser.js --open --title 'h3-js benchmarks'",
-    "prepublishOnly": "yarn dist",
+    "prepublishOnly": "yarn dist && git diff --exit-code",
     "prettier": "prettier --write --config .prettierrc 'lib/**/*.js' 'build/**/*.js' 'test/**/*.js'"
   },
   "browser": {


### PR DESCRIPTION
The `v4.0.0-rc2` release seems to have included WIP changes that weren't intended in the package, due to some inconsistency in my local env. This updates the pre-publish script to fail if there are uncommitted changes after running the distribution build.