### PR TITLE
Prepare for release v4.0.0-rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file. This library adheres to a versioning policy described in [the README](./README.md#versioning). The public API of this library consists of the functions exported in [h3core.js](./lib/h3core.js).
 
 ## [Unreleased]
+
+## [4.0.0-rc3] - 2022-08-11
 ### Fixed
 - Fail package publish if there are library changes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "h3-js",
-  "version": "4.0.0-rc2",
+  "version": "4.0.0-rc3",
   "description": "Pure-Javascript version of the H3 library, a hexagon-based geographic grid system",
   "author": "Nick Rabinowitz <nickr@uber.com>",
   "contributors": [


### PR DESCRIPTION
- Updates version
- Updates CHANGELOG

The new release is primarily due to the issue explained in #148 - I think the current RC 2 release has WIP changes that weren't intended for release.