### PR TITLE
Fix build script for browser output

### DIFF
--- a/scripts/update-emscripten.sh
+++ b/scripts/update-emscripten.sh
@@ -55,6 +55,10 @@ emcc -O3 -I ../include *.c -DH3_HAVE_VLA --memory-init-file 0 \
     -s EXPORTED_FUNCTIONS=$bound_functions \
     -s EXTRA_EXPORTED_RUNTIME_METHODS='["cwrap", "getValue", "setValue"]' \
     "$@"
-cat ../../../../build/pre.js *.js > ../../../../out/libh3.js
+
+for file in *.js ; do
+  cat ../../../../build/pre.js "$file" > ../../../../out/"$file"
+done
+
 popd
 popd


### PR DESCRIPTION
I didn't realize that #153 broke the browser build, because it wrote to `libh3.js` and not `libh3-browser.js` when that was the specified outfile.