### PR TITLE
Fix type hints from H3Index to H3IndexInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. This librar
 ## [Unreleased]
 ### Fixed
 - Patch libh3 bundles to check for `typeof document != "undefined"` before accessing `document`. This allows h3-js to be used in a Web Worker and React Native
+- Fix H3Index type hints for `cellToBoundary`, `cellArea`, `edgeLength`
 
 ## [4.0.1] - 2022-09-19
 ### Changed

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ function may return up to 10 vertices.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| h3Index | <code>H3Index</code> | H3 index |
+| h3Index | <code>H3IndexInput</code> | H3 index |
 | [formatAsGeoJson] | <code>boolean</code> | Whether to provide GeoJSON output: [lng, lat], closed loops |
 
 
@@ -847,7 +847,7 @@ Exact area of a given cell
 
 | Param | Type | Description |
 | --- | --- | --- |
-| h3Index | <code>H3Index</code> | H3 index of the hexagon to measure |
+| h3Index | <code>H3IndexInput</code> | H3 index of the hexagon to measure |
 | unit | <code>string</code> | Distance unit (either UNITS.m2, UNITS.km2, or UNITS.rads2) |
 
 
@@ -866,7 +866,7 @@ Calculate length of a given unidirectional edge
 
 | Param | Type | Description |
 | --- | --- | --- |
-| edge | <code>H3Index</code> | H3 index of the edge to measure |
+| edge | <code>H3IndexInput</code> | H3 index of the edge to measure |
 | unit | <code>string</code> | Distance unit (either UNITS.m, UNITS.km, or UNITS.rads) |
 
 

--- a/lib/h3core.js
+++ b/lib/h3core.js
@@ -725,7 +725,7 @@ export function cellToLatLng(h3Index) {
  * points. For pentagons and hexagons on the edge of an icosahedron face, this
  * function may return up to 10 vertices.
  * @static
- * @param  {H3Index} h3Index          H3 index
+ * @param  {H3IndexInput} h3Index          H3 index
  * @param {boolean} [formatAsGeoJson] Whether to provide GeoJSON output: [lng, lat], closed loops
  * @return {CoordPair[]}              Array of [lat, lng] pairs
  * @throws {H3Error}                  If input is invalid
@@ -1395,7 +1395,7 @@ export function greatCircleDistance(latLng1, latLng2, unit) {
 /**
  * Exact area of a given cell
  * @static
- * @param  {H3Index} h3Index  H3 index of the hexagon to measure
+ * @param  {H3IndexInput} h3Index  H3 index of the hexagon to measure
  * @param  {string}  unit     Distance unit (either UNITS.m2, UNITS.km2, or UNITS.rads2)
  * @return {number}           Cell area
  * @throws {H3Error}          If the input is invalid
@@ -1426,7 +1426,7 @@ export function cellArea(h3Index, unit) {
 /**
  * Calculate length of a given unidirectional edge
  * @static
- * @param  {H3Index} edge     H3 index of the edge to measure
+ * @param  {H3IndexInput} edge     H3 index of the edge to measure
  * @param  {string}  unit     Distance unit (either UNITS.m, UNITS.km, or UNITS.rads)
  * @return {number}           Cell area
  * @throws {H3Error}          If the input is invalid


### PR DESCRIPTION
Noticed that `cellToBoundary` was type hinted to accept `H3Index` however it actually can accept `H3InputIndex`. Updated type hints for `cellToBoundary` and a few other functions I noticed that had the same problem.