### PR TITLE
Update method name in documentation to match V4 name

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ ordered by distance from the origin. The order of the hexagons within each ring 
 
 ### h3.gridRingUnsafe(h3Index, ringSize) ⇒ <code>Array.&lt;H3Index&gt;</code>
 Get all hexagons in a hollow hexagonal ring centered at origin with sides of a given length.
-Unlike kRing, this function will throw an error if there is a pentagon anywhere in the ring.
+Unlike gridDisk, this function will throw an error if there is a pentagon anywhere in the ring.
 
 **Returns**: <code>Array.&lt;H3Index&gt;</code> - H3 indexes for all hexagons in ring  
 **Throws**:

--- a/lib/h3core.js
+++ b/lib/h3core.js
@@ -964,7 +964,7 @@ export function gridDiskDistances(h3Index, ringSize) {
 
 /**
  * Get all hexagons in a hollow hexagonal ring centered at origin with sides of a given length.
- * Unlike kRing, this function will throw an error if there is a pentagon anywhere in the ring.
+ * Unlike gridDisk, this function will throw an error if there is a pentagon anywhere in the ring.
  * @static
  * @param  {H3IndexInput} h3Index  H3 index of center hexagon
  * @param  {number} ringSize  Radius of ring


### PR DESCRIPTION
The function name `kRing` is the name of a V3 function. I simply updated the documentation to the V4 name. `gridDisk`