### PR TITLE
fix: patch __dirname for ESM environments

### DIFF
--- a/scripts/update-emscripten.sh
+++ b/scripts/update-emscripten.sh
@@ -59,8 +59,11 @@ emcc -O3 -I ../include *.c -DH3_HAVE_VLA --memory-init-file 0 \
 for file in *.js ; do
   # Patch libh3 bundle to contain a fix to allow h3-js to be imported in a web worker and react-native
   # See #117 and #163 for more details.
+  # Also patch __dirname for ESM environments (Cloudflare Workers, Node ESM, Deno, Bun)
+  # See #216 for more details.
   cat ../../../../build/pre.js "$file" \
   | sed 's/if(document.currentScript)/if(typeof document!=="undefined" \&\& document.currentScript)/g' \
+  | sed 's/scriptDirectory=__dirname+"\/"/scriptDirectory=typeof __dirname!=="undefined"?__dirname+"\/":""/g' \
   > ../../../../out/"$file"
 done
 


### PR DESCRIPTION
Hey! Ran into this issue deploying to Cloudflare Workers and dug into the root cause.

## The problem

The generated `libh3.js` uses `__dirname` for Node detection:

```javascript
scriptDirectory=__dirname+"/"
```

This breaks in ESM environments where `__dirname` doesn't exist — Cloudflare Workers, Node ESM, Deno, Bun, etc.

## The fix

Added a sed replacement in the build script (same approach as the existing `document.currentScript` patch from #117 and #163):

```javascript
scriptDirectory=typeof __dirname!=="undefined"?__dirname+"/":""
```

## Why it's safe

h3-js embeds memory init as a base64 data URI, so `scriptDirectory` falling back to `""` works fine — it's never actually used to resolve file paths in bundled deployments.

## Testing

- Verified the sed pattern matches the generated `out/libh3.js`
- Tested in Cloudflare Workers — works
- Backwards compatible — Node CJS still gets `__dirname` as before

Fixes #216