### PR TITLE
ci: declare read-only token permissions on test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   
   # Run quick tests for all Node versions


### PR DESCRIPTION
Adds a top-level `permissions: contents: read` declaration to the test workflow.

The workflow checks out code, builds the project, and runs tests. The GITHUB_TOKEN is only passed to the Coveralls action for coverage upload, which works with read-only access. Declaring explicit permissions restricts the token to the minimum scope needed.